### PR TITLE
Upload images to vesta with metadata

### DIFF
--- a/deepocli/cli_parser.py
+++ b/deepocli/cli_parser.py
@@ -44,6 +44,7 @@ def parse_args(args):
     feedback_parser.add_argument('org_slug', type=str, help='the slug of your organization')
     feedback_parser.add_argument('path', type=str, nargs='+', help='path to a file or a folder')
     feedback_parser.add_argument('--recursive', dest='recursive', action='store_true', help='all files in subdirectory')
+    feedback_parser.add_argument('--json', dest='json_file', action='store_true', help='dataset described by json files')
 
     return argparser.parse_args(args)
 

--- a/deepocli/cmds/feedback.py
+++ b/deepocli/cmds/feedback.py
@@ -1,11 +1,12 @@
 import sys
+import os
 from .studio_helpers.http_helper import HTTPHelper
 from .studio_helpers.image import Image
 from .studio_helpers.task import Task
 
 ###############################################################################
 
-API_HOST = 'https://studio.deepomatic.com/api/'
+API_HOST = os.getenv('STUDIO_URL', 'https://studio.deepomatic.com/api/')
 
 
 ###############################################################################
@@ -23,5 +24,5 @@ class Client(object):
 def main(args):
     clt = Client()
     for path in args.get('path', []):
-        clt.image.post_images(args.get('dataset_name', ''), path, args.get('org_slug', ''), args.get('recursive', False))
+        clt.image.post_images(args.get('dataset_name', ''), path, args.get('org_slug', ''), args.get('recursive', False), args.get('json_file', False))
     print("Done")

--- a/deepocli/cmds/studio_helpers/http_helper.py
+++ b/deepocli/cmds/studio_helpers/http_helper.py
@@ -43,6 +43,7 @@ class HTTPHelper(object):
             'Authorization': "Token {}".format(self.token),
         }
         self.session = requests.Session()
+        requests.adapters.HTTPAdapter(pool_connections=1, pool_maxsize=5)
         self.session.headers.update(headers)
         # Use pool_maxsize to cache connections for the same host
         adapter = requests.adapters.HTTPAdapter(pool_maxsize=pool_maxsize)

--- a/deepocli/cmds/studio_helpers/http_helper.py
+++ b/deepocli/cmds/studio_helpers/http_helper.py
@@ -19,7 +19,7 @@ class HTTPHelper(object):
 
         if not host.endswith('/'):
             host += '/'
-
+        host = 'http://127.0.0.1:8000/api/'
         python_version = "{0}.{1}.{2}".format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
 
         user_agent_params = {

--- a/deepocli/cmds/studio_helpers/http_helper.py
+++ b/deepocli/cmds/studio_helpers/http_helper.py
@@ -19,7 +19,6 @@ class HTTPHelper(object):
 
         if not host.endswith('/'):
             host += '/'
-        host = 'http://127.0.0.1:8000/api/'
         python_version = "{0}.{1}.{2}".format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
 
         user_agent_params = {

--- a/deepocli/cmds/studio_helpers/image.py
+++ b/deepocli/cmds/studio_helpers/image.py
@@ -45,13 +45,13 @@ def worker(self):
                     rq = self._helper.post(url, data={"meta": data}, content_type='multipart/form', files={"file": fd})
                 self._task.retrieve(rq['task_id'])
             except RuntimeError:
-                print('Annotation format for image named {} is incorrect'.format(file))
+                logging.error('Annotation format for image named {} is incorrect'.format(file))
             q.task_done()
             lock.acquire()
             count += 1
             lock.release()
             if count % 10 == 0:
-                print('{} files uploaded'.format(count))
+                logging.info('{} files uploaded'.format(count))
         except Queue.Empty:
             pass
 

--- a/deepocli/cmds/studio_helpers/image.py
+++ b/deepocli/cmds/studio_helpers/image.py
@@ -45,7 +45,7 @@ def worker(self):
                     rq = self._helper.post(url, data={"meta": data}, content_type='multipart/form', files={"file": fd})
                 self._task.retrieve(rq['task_id'])
             except RuntimeError:
-                pass
+                print('Annotation format for image named {} is incorrect'.format(file))
             q.task_done()
             lock.acquire()
             count += 1

--- a/deepocli/cmds/studio_helpers/image.py
+++ b/deepocli/cmds/studio_helpers/image.py
@@ -40,9 +40,12 @@ def worker(self):
     while run:
         try:
             url, data, file = q.get(timeout=2)
-            with open(file, 'rb') as fd:
-                rq = self._helper.post(url, data={"meta": data}, content_type='multipart/form', files={"file": fd})
-            self._task.retrieve(rq['task_id'])
+            try:
+                with open(file, 'rb') as fd:
+                    rq = self._helper.post(url, data={"meta": data}, content_type='multipart/form', files={"file": fd})
+                self._task.retrieve(rq['task_id'])
+            except RuntimeError:
+                pass
             q.task_done()
             lock.acquire()
             count += 1

--- a/deepocli/cmds/studio_helpers/image.py
+++ b/deepocli/cmds/studio_helpers/image.py
@@ -5,7 +5,12 @@ import json
 import logging
 import uuid
 import threading
-import Queue
+import sys
+
+if sys.version_info >= (3,0):
+    import queue as Queue
+else:
+    import Queue
 from .task import Task
 import logging
 import time

--- a/deepocli/cmds/studio_helpers/image.py
+++ b/deepocli/cmds/studio_helpers/image.py
@@ -1,27 +1,50 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
+import json
+import logging
+import uuid
 from .task import Task
 
-supported_image_formats = ['bmp', 'jpeg', 'jpg', 'jpe', 'png']
+supported_formats = ['bmp', 'jpeg', 'jpg', 'jpe', 'png']
+FLUSH_SIZE = 25 # arbitrary size
 
 def get_files(path, recursive=True):
     if os.path.isfile(path):
-        if path.split('.')[-1].lower() in supported_image_formats:
+        if path.split('.')[-1].lower() in supported_formats:
             yield path
     elif os.path.isdir(path):
         if recursive:
             for root, dirs, files in os.walk(path, topdown=False):
                 for name in files:
-                    if name.split('.')[-1].lower() in supported_image_formats:
+                    if name.split('.')[-1].lower() in supported_formats:
                         yield os.path.join(root, name)
         else:
             for file in os.listdir(path):
                 file_path = os.path.join(path, file)
-                if os.path.isfile(file_path) and file_path.split('.')[-1].lower() in supported_image_formats:
+                if os.path.isfile(file_path) and file_path.split('.')[-1].lower() in supported_formats:
                     yield  file_path
     else:
-        raise RuntimeError("The path {} is neither a file nor a directory".format(path))
+        raise RuntimeError("The path {} is neither a image file nor a directory".format(path))
+
+def get_json(path, recursive=True):
+    if os.path.isfile(path):
+        if path.split('.')[-1].lower() == 'json':
+            yield path
+    elif os.path.isdir(path):
+        if recursive:
+            for root, dirs, files in os.walk(path, topdown=False):
+                for name in files:
+                    if name.split('.')[-1].lower() == 'json':
+                        yield os.path.join(root, name)
+        else:
+            for file in os.listdir(path):
+                file_path = os.path.join(path, file)
+                if os.path.isfile(file_path) and file_path.split('.')[-1].lower() == 'json':
+                    yield  file_path
+    else:
+        raise RuntimeError("The path {} is neither a json file nor a directory".format(path))
+
 
 class Image(object):
     def __init__(self, helper, task=None):
@@ -31,29 +54,61 @@ class Image(object):
         self._task = task
 
 
-    def post_images(self, dataset_name, path, org_slug, recursive=False):
+    def post_images(self, dataset_name, path, org_slug, recursive=False, json_file=False):
         try:
             ret = self._helper.get('datasets/' + dataset_name + '/')
         except RuntimeError as err:
             raise RuntimeError("Can't find the dataset {}".format(dataset_name))
-
         commit_pk = ret['commits'][0]['uuid']
 
-        data = {
-            "task": "import_images",
-            "org_slug": org_slug,
-            "cuuid": commit_pk,
-            "dataset_name": dataset_name
-        }
         if not isinstance(path, list):
             path = [path]
-        files = []
+        rq = []
+        files = {}
         for elem in path:
-            for file in get_files(elem, recursive):
-                files.append(('files', open(file, 'rb')))
-                if len(files) > 25:  # arbitrary size
-                    self._task.retrieve(self._helper.post('action/', data=data, content_type='multipart/form', files=files)['task_id'])
-                    files = []
+            if not json_file:
+                for file in get_files(elem, recursive):
+                    tmp_name = uuid.uuid4().hex
+                    rq.append({'location': tmp_name})
+                    files[tmp_name] = open(file, 'rb')
+                    if len(files) > FLUSH_SIZE:
+                        self._task.retrieve(self._helper.post('v1/datasets/{}/commits/{}/images/batch/'.format(dataset_name, commit_pk), data=rq, content_type='multipart/form', files=files)['task_id'])
+                        rq = []
+                        files = {}
+            else:
+                for file in get_json(elem, recursive):
+                    try:
+                        with open(file, 'rb') as fd:
+                            json_objects = json.load(fd)
+                    except ValueError:
+                        logging.error("Can't read file {}, skipping...".format(file))
+                        continue
+                    if isinstance(json_objects, dict):
+                        if 'location' not in json_objects:
+                            for ext in ('bmp', 'jpeg', 'jpg', 'jpe', 'png'):
+                                tmp_path = os.path.join(os.path.dirname(file), os.path.basename(file).replace('json', ext))
+                                if os.path.isfile(tmp_path):
+                                    json_objects['location'] = tmp_path
+                                    json_objects = [json_objects]
+                                    break
+                            else:
+                                logging.error("Can't find an image named {}".format(os.path.basename(file)))
+                                continue
+                    for i, json_object in enumerate(json_objects):
+                        image_path = os.path.join(os.path.dirname(file), json_object['location'])
+                        if not os.path.isfile(image_path):
+                            logging.error("Can't find an image named {}".format(json_object['location']))
+                            continue
+                        image_key = uuid.uuid4().hex
+                        files[image_key] = open(image_path, 'rb')
+                        json_object['location'] = image_key
+                        rq.append(json_object)
+                        if len(files) > FLUSH_SIZE:
+                            self._task.retrieve(self._helper.post('v1/datasets/{}/commits/{}/images/batch/'.format(dataset_name, commit_pk), data={"objects": json.dumps(rq)}, content_type='multipart/form', files=files)['task_id'])
+                            rq = []
+                            files = {}
+
+        # flush
         if len(files):
-            self._task.retrieve(self._helper.post('action/', data=data, content_type='multipart/form', files=files)['task_id'])
+            self._task.retrieve(self._helper.post('v1/datasets/{}/commits/{}/images/batch/'.format(dataset_name, commit_pk), data={"objects": json.dumps(rq)}, content_type='multipart/form', files=files)['task_id'])
         return True

--- a/deepocli/cmds/studio_helpers/task.py
+++ b/deepocli/cmds/studio_helpers/task.py
@@ -6,7 +6,6 @@ class Task(object):
         self._helper = helper
 
     def retrieve(self, task_id, wait=True):
-        print(task_id)
         ret = self._helper.get('manage/tasks/{}/'.format(task_id))
         if not wait:
             return ret


### PR DESCRIPTION
**Do not merge before the January studio release**


This PR upgrade the deepo client in order to send images with meta data to deepomatic studio.
You can use deepocli with a new option `--json` such as:
`deepo feedback yoyo defaultorg /tmp/test_files/ --json`
This command will fetch all the json files in the current directory and subdirectory and upload it to studio.
An object is defined such as 
```json
    {
      "location": "000018acd19b4ad1.jpg",
      "stage": "train",
      "annotated_regions": [
        {
          "tags": ["Statue", "Crystal"],
          "region_type": "Whole"
        }
      ],
    "data": {}
    }
```
- `location` the path of the image (relative to the json file)
- `stage`: "the stage of the image (train or val)
- `annotated_regions`:  annotations 
- `data`: meta information, need to be an object
All this fields are optional however if you remove the field location you need to have an image with the same name as the json file.
For information about the format can be found [here](https://docs.deepomatic.com/studio/adding-images/json-upload)

The deepomatic client accept two formats for the json:
Or a list of images such as 
```json
[{
    "location": "000018acd19b4ad1.jpg",
    "annotated_regions": [{
        "region_type": "Box",
        "region": {
            "xmin": 0.485351562,
            "ymin": 0.121522694,
            "ymax": 0.609077599,
            "xmax": 0.805664062
        },
        "tags": ["Statue"]
    }, {
        "region_type": "Box",
        "region": {
            "xmin": 0.231445312,
            "ymin": 0.273792094,
            "ymax": 0.775988287,
            "xmax": 0.706054688
        },
        "tags": ["Crystal"]
    }],
    "stage": "train"
}, {
    "location": "000018acd19b4ad3.jpg",
    "data": {
        "key": "value"
    },
    "stage": "train"
}]
```

or a single object 
```json
{"data": {"key": "value"}}
```