### PR TITLE
add -json flag to the draw and blur command for every kind of output

### DIFF
--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -47,9 +47,11 @@ def argparser_init():
 
     draw_parser.add_argument('--draw_scores', help="Overlays the prediction scores.", action="store_true")
     draw_parser.add_argument('--draw_labels', help="Overlays the prediction labels.", action="store_true")
+    draw_parser.add_argument('--json', help="Save the corresponding prediction in a json file.", action="store_true")
 
     blur_parser.add_argument('--blur_method', help="Blur method to apply, either 'pixel', 'gaussian' or 'black', defaults to 'pixel'.", default='pixel', choices=['pixel', 'gaussian', 'black'])
     blur_parser.add_argument('--blur_strength', help="Blur strength, defaults to 10.", default=10)
+    blur_parser.add_argument('--json', help="Save the corresponding prediction in a json file.", action="store_true")
 
     feedback_parser.add_argument('-d', '--dataset', required=True, help="Deepomatic Studio dataset name.", type=str)
     feedback_parser.add_argument('-o', '--organization', required=True, help="Deepomatic Studio organization slug.", type=str)

--- a/deepomatic/cli/io_data.py
+++ b/deepomatic/cli/io_data.py
@@ -25,7 +25,7 @@ def save_json_to_file(json_data, json_path):
             print_log('Writing %s.json' % json_path)
             json.dump(json_data, file)
     except:
-        logging.error("Could not save file {json_path} in json format.")
+        logging.error("Could not save file {} in json format.".format(json_path))
         raise
 
     return

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -30,3 +30,9 @@ def test_e2e_image_blur_image_strength():
 
 def test_e2e_video_blur_video():
     run(['blur', '-i', video_path, '--recognition_id', 'fashion-v4', '-o', '/tmp/test.mp4'])
+
+def test_e2e_image_blur_json_flag():
+    run(['blur', '-i', image_path, '--recognition_id', 'fashion-v4', '-o', '/tmp/test_json_flag.jpeg', '--json'])
+
+def test_e2e_video_blur_json_flag():
+    run(['blur', '-i', video_path, '--recognition_id', 'fashion-v4', '-o', '/tmp/test_json_flag.mp4', '--json'])

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -44,3 +44,9 @@ def test_e2e_video_draw_stdout():
 def test_e2e_video_draw_window():
     return
     run(['draw', '-i', video_path, '--recognition_id', 'fashion-v4', '-o', 'window'])
+
+def test_e2e_image_draw_json_flag():
+    run(['draw', '-i', image_path, '--recognition_id', 'fashion-v4', '-o', '/tmp/test_json_flag.jpeg', '--json'])
+
+def test_e2e_video_draw_json_flag():
+    run(['draw', '-i', video_path, '--recognition_id', 'fashion-v4', '-o', '/tmp/test_json_flag.mp4', '--json'])


### PR DESCRIPTION
to validate https://airtable.com/tbl0NdAjudtx4qYPZ/viwijmP4oeTteyEJD/recZOp7TxlcihbvqT?blocks=hide

This pull request: 

- adds a _json flag to the `draw` command to parse the predictions in a json
- adds a _json flag to the `blur` command to parse the predictions in a json
- works for any kind of output (image or directory output will return a json by frame, video output will return a json for the whole video analyzing frame by frame) 