### PR TITLE
Multiple outputs

### DIFF
--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -53,11 +53,9 @@ def argparser_init():
 
     draw_parser.add_argument('--draw_scores', help="Overlays the prediction scores.", action="store_true")
     draw_parser.add_argument('--draw_labels', help="Overlays the prediction labels.", action="store_true")
-    draw_parser.add_argument('--json', help="Saves predictions in a json file.", action="store_true")
 
     blur_parser.add_argument('--blur_method', help="Blur method to apply, either 'pixel', 'gaussian' or 'black', defaults to 'pixel'.", default='pixel', choices=['pixel', 'gaussian', 'black'])
     blur_parser.add_argument('--blur_strength', help="Blur strength, defaults to 10.", default=10)
-    blur_parser.add_argument('--json', help="Saves predictions in a json file.", action="store_true")
 
     feedback_parser.add_argument('-d', '--dataset', required=True, help="Deepomatic Studio dataset name.", type=str)
     feedback_parser.add_argument('-o', '--organization', required=True, help="Deepomatic Studio organization slug.", type=str)

--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -41,7 +41,7 @@ def argparser_init():
 
     for parser in [infer_parser, draw_parser, blur_parser]:
         parser.add_argument('-i', '--input', required=True, help="Path on which inference should be run. It can be an image (supported formats: *{}), a video (supported formats: *{}) or a directory. If the given path is a directory, it will recursively run inference on all the supported files in this directory.".format(', *'.join(ImageInputData.supported_formats), ', *'.join(VideoInputData.supported_formats)))
-        parser.add_argument('-o', '--output', required=True, help="Path in which output should be written. It can be an image (supported formats: *{}), a video (supported formats: *{}) or a directory.".format(', *'.join(ImageInputData.supported_formats), ', *'.join(VideoInputData.supported_formats)))
+        parser.add_argument('-o', '--outputs', required=True, nargs='+', help="Path in which output should be written. It can be an image (supported formats: *{}), a video (supported formats: *{}) or a directory.".format(', *'.join(ImageInputData.supported_formats), ', *'.join(VideoInputData.supported_formats)))
         parser.add_argument('-r', '--recognition_id', required=True, help="Neural network recognition version ID.")
         parser.add_argument('-u', '--amqp_url', help="AMQP url for on-premises deployments.")
         parser.add_argument('-k', '--routing_key', help="Recognition routing key for on-premises deployments.")

--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -72,7 +72,7 @@ class InferenceThread(threading.Thread):
             self.workflow.close()
 
     def processing(self, name, frame, prediction):
-        return name, None, prediction
+        return name, frame, prediction
 
 
 def main(args, force=False):

--- a/deepomatic/cli/io_data.py
+++ b/deepomatic/cli/io_data.py
@@ -508,9 +508,6 @@ class ImageOutputData(OutputData):
             else:
                 print_log('Writing %s' % path)
                 cv2.imwrite(path, frame)
-                if self._json:
-                    json_path = os.path.splitext(path)[0]
-                    save_json_to_file(prediction, json_path)
 
 
 class VideoOutputData(OutputData):
@@ -540,9 +537,6 @@ class VideoOutputData(OutputData):
         return self
 
     def __exit__(self, exception_type, exception_value, traceback):
-        if self._json:
-            json_path = os.path.splitext(self._descriptor)[0]
-            save_json_to_file(self._all_predictions, json_path)
         if self._writer is not None:
             self._writer.release()
         self._writer = None
@@ -557,9 +551,6 @@ class VideoOutputData(OutputData):
                     self._fourcc,
                     self._fps,
                     (frame.shape[1], frame.shape[0]))
-            if self._json:
-                self._all_predictions['images'] += prediction['images']
-                self._all_predictions['tags'] = list(set(self._all_predictions['tags'] + prediction['tags']))
             self._writer.write(frame)
 
 class DirectoryOutputData(OutputData):
@@ -588,8 +579,6 @@ class DirectoryOutputData(OutputData):
         else:
             print_log('Writing %s.jpeg' % path)
             cv2.imwrite('%s.jpeg' % path, frame)
-            if self._json:
-                save_json_to_file(prediction, path)
 
 class DrawOutputData(OutputData):
 

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -13,6 +13,7 @@ image_output = os.path.join(dir_output, 'image_output%4d.jpg')
 video_output = os.path.join(dir_output, 'video_output%4d.mp4')
 json_output = os.path.join(dir_output, 'test_output%4d.json')
 directory_output = dir_output
+outputs = [std_output, image_output, video_output, json_output, directory_output]
 
 
 # ------- Image Input Tests ------------------------------------------------------------------------------------------ #
@@ -32,6 +33,9 @@ def test_e2e_image_blur_json(test_input=image_input, test_output=json_output):
 def test_e2e_image_blur_directory(test_input=image_input, test_output=directory_output):
     run(['blur', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
+def test_e2e_image_blur_multiples(test_input=image_input, test_output=outputs):
+    run(['blur', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
+
 
 # ------- Video Input Tests ------------------------------------------------------------------------------------------ #
 
@@ -50,6 +54,8 @@ def test_e2e_video_blur_json(test_input=video_input, test_output=json_output):
 def test_e2e_video_blur_directory(test_input=video_input, test_output=directory_output):
     run(['blur', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
+def test_e2e_video_blur_multiples(test_input=video_input, test_output=outputs):
+    run(['blur', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
 
 # ------- Directory Input Tests -------------------------------------------------------------------------------------- #
 
@@ -68,6 +74,8 @@ def test_e2e_directory_blur_json(test_input=directory_input, test_output=json_ou
 def test_e2e_directory_blur_directory(test_input=directory_input, test_output=directory_output):
     run(['blur', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
+def test_e2e_directory_blur_multiples(test_input=directory_input, test_output=outputs):
+    run(['blur', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
 
 # ------- Json Input Tests ------------------------------------------------------------------------------------------- #
 
@@ -86,6 +94,9 @@ def test_e2e_json_blur_json(test_input=json_input, test_output=json_output):
 def test_e2e_json_blur_directory(test_input=json_input, test_output=directory_output):
     run(['blur', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
+def test_e2e_json_blur_multiples(test_input=json_input, test_output=outputs):
+    run(['blur', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
+
 
 # ------- Special Options Tests -------------------------------------------------------------------------------------- #
 
@@ -98,9 +109,6 @@ def test_e2e_video_blur_video_fps(test_input=video_input, test_output=video_outp
 def test_e2e_image_blur_image_window(test_input=image_input, test_output='window'):
     return  # window not handled by test
     run(['blur', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--fullscreen'])
-
-def test_e2e_image_blur_image_json(test_input=image_input, test_output=image_output):
-    run(['blur', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--json'])
 
 def test_e2e_image_blur_image_method(test_input=image_input, test_output=image_output):
     run(['blur', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--blur_method', 'pixel'])

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -13,7 +13,7 @@ image_output = os.path.join(dir_output, 'image_output%4d.jpg')
 video_output = os.path.join(dir_output, 'video_output%4d.mp4')
 json_output = os.path.join(dir_output, 'test_output%4d.json')
 directory_output = dir_output
-
+outputs = [std_output, image_output, video_output, json_output, directory_output]
 
 # ------- Image Input Tests ------------------------------------------------------------------------------------------ #
 
@@ -31,6 +31,9 @@ def test_e2e_image_draw_json(test_input=image_input, test_output=json_output):
 
 def test_e2e_image_draw_directory(test_input=image_input, test_output=directory_output):
     run(['draw', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
+
+def test_e2e_image_draw_multiples(test_input=image_input, test_output=outputs):
+    run(['draw', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
 
 
 # ------- Video Input Tests ------------------------------------------------------------------------------------------ #
@@ -50,6 +53,8 @@ def test_e2e_video_draw_json(test_input=video_input, test_output=json_output):
 def test_e2e_video_draw_directory(test_input=video_input, test_output=directory_output):
     run(['draw', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
+def test_e2e_video_draw_multiples(test_input=video_input, test_output=outputs):
+    run(['draw', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
 
 # ------- Directory Input Tests -------------------------------------------------------------------------------------- #
 
@@ -68,6 +73,8 @@ def test_e2e_directory_draw_json(test_input=directory_input, test_output=json_ou
 def test_e2e_directory_draw_directory(test_input=directory_input, test_output=directory_output):
     run(['draw', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
+def test_e2e_directory_draw_multiples(test_input=directory_input, test_output=outputs):
+    run(['draw', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
 
 # ------- Json Input Tests ------------------------------------------------------------------------------------------- #
 
@@ -86,6 +93,10 @@ def test_e2e_json_draw_json(test_input=json_input, test_output=json_output):
 def test_e2e_json_draw_directory(test_input=json_input, test_output=directory_output):
     run(['draw', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
+def test_e2e_json_draw_multiples(test_input=json_input, test_output=outputs):
+    run(['draw', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
+
+
 
 # ------- Special Options Tests -------------------------------------------------------------------------------------- #
 
@@ -98,9 +109,6 @@ def test_e2e_video_draw_video_fps(test_input=video_input, test_output=video_outp
 def test_e2e_image_draw_image_window(test_input=image_input, test_output='window'):
     return  # window not handled by test
     run(['draw', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--fullscreen'])
-
-def test_e2e_image_draw_image_json(test_input=image_input, test_output=image_output):
-    run(['draw', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--json'])
 
 def test_e2e_image_draw_image_scores(test_input=image_input, test_output=image_output):
     run(['draw', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--draw_scores'])

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -7,13 +7,22 @@ from deepomatic.cli.cli_parser import run
 
 # Input to test: Image, Video, Directory, Json
 image_input, video_input, directory_input, json_input, dir_output = init_files_setup()
-# Output to test: Stdout, Json, Directory
+# Output to test: Image, Video, Stdout, Json, Directory
 std_output = 'stdout'
+image_output = os.path.join(dir_output, 'image_output%4d.jpg')
+video_output = os.path.join(dir_output, 'video_output%4d.mp4')
 json_output = os.path.join(dir_output, 'test_output%4d.json')
 directory_output = dir_output
+outputs = [std_output, image_output, video_output, json_output, directory_output]
 
 
 # ------- Image Input Tests ------------------------------------------------------------------------------------------ #
+
+def test_e2e_image_infer_image(test_input=image_input, test_output=image_output):
+    run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
+
+def test_e2e_image_infer_video(test_input=image_input, test_output=video_output):
+    run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
 def test_e2e_image_infer_stdout(test_input=image_input, test_output=std_output):
     run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
@@ -24,8 +33,17 @@ def test_e2e_image_infer_json(test_input=image_input, test_output=json_output):
 def test_e2e_image_infer_directory(test_input=image_input, test_output=directory_output):
     run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
+def test_e2e_image_infer_multiples(test_input=image_input, test_output=outputs):
+    run(['infer', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
+
 
 # ------- Video Input Tests ------------------------------------------------------------------------------------------ #
+
+def test_e2e_video_infer_image(test_input=video_input, test_output=image_output):
+    run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
+
+def test_e2e_video_infer_video(test_input=video_input, test_output=video_output):
+    run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
 def test_e2e_video_infer_stdout(test_input=video_input, test_output=std_output):
     run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
@@ -36,8 +54,16 @@ def test_e2e_video_infer_json(test_input=video_input, test_output=json_output):
 def test_e2e_video_infer_directory(test_input=video_input, test_output=directory_output):
     run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
+def test_e2e_video_infer_multiples(test_input=video_input, test_output=outputs):
+    run(['infer', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
 
 # ------- Directory Input Tests -------------------------------------------------------------------------------------- #
+
+def test_e2e_directory_infer_image(test_input=directory_input, test_output=image_output):
+    run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
+
+def test_e2e_directory_infer_video(test_input=directory_input, test_output=video_output):
+    run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
 def test_e2e_directory_infer_stdout(test_input=directory_input, test_output=std_output):
     run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
@@ -48,8 +74,16 @@ def test_e2e_directory_infer_json(test_input=directory_input, test_output=json_o
 def test_e2e_directory_infer_directory(test_input=directory_input, test_output=directory_output):
     run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
+def test_e2e_directory_infer_multiples(test_input=directory_input, test_output=outputs):
+    run(['infer', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
 
 # ------- Json Input Tests ------------------------------------------------------------------------------------------- #
+
+def test_e2e_json_infer_image(test_input=json_input, test_output=image_output):
+    run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
+
+def test_e2e_json_infer_video(test_input=json_input, test_output=video_output):
+    run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
 
 def test_e2e_json_infer_stdout(test_input=json_input, test_output=std_output):
     run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
@@ -59,6 +93,9 @@ def test_e2e_json_infer_json(test_input=json_input, test_output=json_output):
 
 def test_e2e_json_infer_directory(test_input=json_input, test_output=directory_output):
     run(['infer', '-i', test_input, '-o', test_output, '-r', 'fashion-v4'])
+
+def test_e2e_json_infer_multiples(test_input=json_input, test_output=outputs):
+    run(['infer', '-i', test_input, '-o', ' '.join(outputs), '-r', 'fashion-v4'])
 
 
 # ------- Special Options Tests -------------------------------------------------------------------------------------- #


### PR DESCRIPTION
I needed to output raw frames (not drawn) and associated predictions, so I made this.
You can now use multiple outputs:
deepo infer -i 192.168.11.21_2019-02-28_12-39-29.mp4 **-o frames_%05d.jpg predictions_%05d.json** -k worker_queue-u amqp://guest:password@0.0.0.0:5672/ -r 30819

![Screenshot from 2019-04-04 11-57-23](https://user-images.githubusercontent.com/7126606/55547914-9be35a80-56d2-11e9-8a3c-af62318ab9ff.png)

I also removed --json since I think it is redundant and less flexible than this.
