### PR TITLE
Harmonizes fps for i/o videos

### DIFF
--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -37,10 +37,10 @@ def argparser_init():
     studio_parser = subparsers.add_parser('studio', help='Deepomatic Studio related commands')
     studio_subparser = studio_parser.add_subparsers(dest='studio_command', help='')
     studio_subparser.required = True
-    feedback_parser = studio_subparser.add_parser('add_images', help='Uploads images from the local machine to Deepomatic Studio.')
-    feedback_parser.set_defaults(func=feedback, recursive=False)
+    add_images_parser = studio_subparser.add_parser('add_images', help='Uploads images from the local machine to Deepomatic Studio.')
+    add_images_parser.set_defaults(func=feedback, recursive=False)
 
-    for parser in [infer_parser, draw_parser, blur_parser, feedback_parser]:
+    for parser in [infer_parser, draw_parser, blur_parser, add_images_parser]:
         parser.add_argument('-R', '--recursive', dest='recursive', action='store_true', help='If a directory input is used, goes through all files in subdirectories.')
 
     for parser in [infer_parser, draw_parser, blur_parser]:
@@ -50,7 +50,8 @@ def argparser_init():
         parser.add_argument('-u', '--amqp_url', help="AMQP url for on-premises deployments.")
         parser.add_argument('-k', '--routing_key', help="Recognition routing key for on-premises deployments.")
         parser.add_argument('-t', '--threshold', type=float, help="Threshold above which a prediction is considered valid.", default=None)
-        parser.add_argument('-f', '--fps', type=int, help="Video frame rate if applicable.")
+        parser.add_argument('--input_fps', type=int, help="FPS for input video frame extraction.", default=None)
+        parser.add_argument('--output_fps', type=int, help="FPS for output video reconstruction.", default=None)
         parser.add_argument('-s', '--studio_format', action='store_true', help="Convert deepomatic run predictions into deepomatic studio format.")
 
     for parser in [draw_parser, blur_parser]:
@@ -62,10 +63,10 @@ def argparser_init():
     blur_parser.add_argument('-M', '--blur_method', help="Blur method to apply, either 'pixel', 'gaussian' or 'black', defaults to 'pixel'.", default='pixel', choices=['pixel', 'gaussian', 'black'])
     blur_parser.add_argument('-B', '--blur_strength', help="Blur strength, defaults to 10.", default=10)
 
-    feedback_parser.add_argument('-d', '--dataset', required=True, help="Deepomatic Studio dataset name.", type=str)
-    feedback_parser.add_argument('-o', '--organization', required=True, help="Deepomatic Studio organization slug.", type=str)
-    feedback_parser.add_argument('path', type=str, nargs='+', help='Path to an image file, images directory or json file or directory.')
-    feedback_parser.add_argument('--json', dest='json_file', action='store_true', help='Look for JSON files instead of images.')
+    add_images_parser.add_argument('-d', '--dataset', required=True, help="Deepomatic Studio dataset name.", type=str)
+    add_images_parser.add_argument('-o', '--organization', required=True, help="Deepomatic Studio organization slug.", type=str)
+    add_images_parser.add_argument('path', type=str, nargs='+', help='Path to an image file, images directory or json file or directory.')
+    add_images_parser.add_argument('--json', dest='json_file', action='store_true', help='Look for JSON files instead of images.')
 
     return argparser
 

--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -50,8 +50,8 @@ def argparser_init():
         parser.add_argument('-u', '--amqp_url', help="AMQP url for on-premises deployments.")
         parser.add_argument('-k', '--routing_key', help="Recognition routing key for on-premises deployments.")
         parser.add_argument('-t', '--threshold', type=float, help="Threshold above which a prediction is considered valid.", default=None)
-        parser.add_argument('--input_fps', type=int, help="FPS for input video frame extraction.", default=None)
-        parser.add_argument('--output_fps', type=int, help="FPS for output video reconstruction.", default=None)
+        parser.add_argument('--input_fps', type=int, help="FPS used for input video frame skipping and extraction. If higher than the original video FPS, all frames will be analysed only once having the same effect as not using this parameter. If lower than the original video FPS, some frames will be discarded to simulate an input of the given FPS.", default=None)
+        parser.add_argument('--output_fps', type=int, help="FPS usef for output video reconstruction.", default=None)
         parser.add_argument('-s', '--studio_format', action='store_true', help="Convert deepomatic run predictions into deepomatic studio format.")
 
     for parser in [draw_parser, blur_parser]:

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -60,6 +60,10 @@ def get_input(descriptor, kwargs):
 def input_loop(kwargs, postprocessing=None):
     inputs = get_input(kwargs.get('input', 0), kwargs)
 
+    # If no fps is specified and input is a video, pass the fps parameter to the output
+    if isinstance(inputs, VideoInputData):
+        kwargs['fps'] = inputs.get_fps()
+
     # Initialize progress bar
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger()

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -58,7 +58,29 @@ def get_input(descriptor, kwargs):
 
 
 def input_loop(kwargs, postprocessing=None):
+    # Adds smartness to fps handling
+    #   1) If both input_fps and output_fps are set, then use them as is.
+    #   2) If only one of the two is used, make both equal
+    #   3) If none is set:
+    #       * If the input is not a video, do nothing and use the default DEFAULT_FPS output value
+    #       * If the input is a video, use the input fps as the output fps
+    if kwargs['input_fps'] and kwargs['output_fps']:
+        pass
+    elif kwargs['input_fps']:
+        kwargs['output_fps'] = kwargs['input_fps']
+        logging.info('Input fps of {} specified, but no output fps specified. Using same value for both.'.format(kwargs['input_fps']))
+    elif kwargs['output_fps']:
+        kwargs['input_fps'] = kwargs['output_fps']
+        logging.info('Output fps of {} specified, but no input fps specified. Using same value for both.'.format(kwargs['output_fps']))
+    
+    # Compute inputs now to access actual input fps if it's a video
     inputs = get_input(kwargs.get('input', 0), kwargs)
+
+    # Deal with last case for fps
+    if not(kwargs['input_fps']) and not(kwargs['output_fps']) and isinstance(inputs, VideoInputData):
+        kwargs['input_fps'] = inputs.get_fps()
+        kwargs['output_fps'] = kwargs['input_fps']
+        logging.info('Input fps of {} automatically detected, but no output fps specified. Using same value for both.'.format(kwargs['input_fps']))
 
     # Initialize progress bar
     logging.basicConfig(level=logging.INFO)

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -273,20 +273,20 @@ class VideoInputData(InputData):
             try:
                 self._video_fps = self._cap.get(cv2.CAP_PROP_FPS)
             except Exception:
-                raise ValueError('Could not read fps for video {}, please specify it with --fps option.'.format(self._descriptor))
+                raise ValueError('Could not read fps for video {}, please specify it with --input_fps option.'.format(self._descriptor))
             if self._video_fps == 0:
-                raise ValueError('Null fps detected for video {}, please specify it with --fps option.'.format(self._descriptor))
+                raise ValueError('Null fps detected for video {}, please specify it with --input_fps option.'.format(self._descriptor))
             
             # Compute fps for frame extraction so that we don't analyze useless frame that will be discarded later
             if not self._kwargs_fps:
                 self._extract_fps = self._video_fps
-                logging.info('No keyword fps specified, using raw video fps of {}'.format(self._video_fps))
+                logging.info('No --input_fps specified, using raw video fps of {}'.format(self._video_fps))
             elif self._kwargs_fps < self._video_fps:
                 self._extract_fps = self._kwargs_fps
-                logging.info('Using keyword fps of {} instead of raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
+                logging.info('Using user-specified --input_fps of {} instead of raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
             else:
                 self._extract_fps = self._video_fps
-                logging.info('Keyword fps of {} specified but using maximum raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
+                logging.info('User-specified --input_fps of {} specified but using maximum raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
 
             # Compute frames corresponding to the new fps
             total_frames = int(self._cap.get(cv2.CAP_PROP_FRAME_COUNT) * self._extract_fps / self._video_fps)

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -240,11 +240,17 @@ class VideoInputData(InputData):
             self._cap.release()
         self._cap = cv2.VideoCapture(self._descriptor)
         self._i = 0
+        self._frames_iter = iter(self._adjusted_frames)
         return self
 
     def __next__(self):
         if self._cap.isOpened():
-            while self._i not in self._adjusted_frames:
+            try:
+                next_frame = next(self._frames_iter)
+            except StopIteration:
+                self._cap.release()
+                raise StopIteration
+            while self._i != next_frame:
                 self._i += 1
                 _, frame = self._cap.read()
                 if frame is None:

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -146,7 +146,7 @@ class VideoOutputData(OutputData):
         elif ext == '.mp4':
             fourcc = cv2.VideoWriter_fourcc('m', 'p', '4', 'v')
         self._fourcc = fourcc
-        self._fps = kwargs['fps'] if kwargs['fps'] else DEFAULT_FPS
+        self._fps = kwargs['output_fps'] if kwargs['output_fps'] else DEFAULT_FPS
         self._writer = None
 
     def close(self):
@@ -181,7 +181,7 @@ class StdOutputData(OutputData):
 class DisplayOutputData(OutputData):
     def __init__(self, **kwargs):
         super(DisplayOutputData, self).__init__(None, **kwargs)
-        self._fps = kwargs.get('fps', DEFAULT_FPS)
+        self._fps = kwargs['output_fps'] if kwargs['output_fps'] else DEFAULT_FPS
         self._window_name = 'Deepomatic'
         self._fullscreen = kwargs.get('fullscreen', False)
 

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -58,16 +58,18 @@ class OutputThread(ThreadBase):
         self.on_progress = on_progress
         self.frames_to_check_first = {}
         self.frame_to_output = 0
-        self.outputs = get_outputs(self.args.get('outputs', None), self.args)
         
         # Update output fps to default value if none was specified.
-        # Logs information only if one of the outputs uses fps.
+        # #Logs information only if one of the outputs uses fps.
         if not kwargs['output_fps']:
             kwargs['output_fps'] = DEFAULT_OUTPUT_FPS
+            self.outputs = get_outputs(self.args.get('outputs', None), self.args)
             for output in outputs:
                 if isinstance(output, VideoOutputData) or isinstance(output, DisplayOutputData):
                     logging.info('No --output_fps value specified for output, using default value of {}.'.format(DEFAULT_OUTPUT_FPS))
                     break
+        else:
+            self.outputs = get_outputs(self.args.get('outputs', None), self.args)
 
 
     def close(self):

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -146,7 +146,13 @@ class VideoOutputData(OutputData):
         elif ext == '.mp4':
             fourcc = cv2.VideoWriter_fourcc('m', 'p', '4', 'v')
         self._fourcc = fourcc
-        self._fps = kwargs['output_fps'] if kwargs['output_fps'] else DEFAULT_FPS
+        if kwargs['output_fps']:
+            self._fps = kwargs['output_fps']
+            logging.info('Using user-specified --output_fps value of {}'.format(kwargs['output_fps']))
+        else:
+            self._fps = DEFAULT_FPS
+            logging.info('No --output_fps specified, using default output fps value of {}'.format(DEFAULT_FPS))
+        
         self._writer = None
 
     def close(self):

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -64,7 +64,7 @@ class OutputThread(ThreadBase):
         if not kwargs['output_fps']:
             kwargs['output_fps'] = DEFAULT_OUTPUT_FPS
             self.outputs = get_outputs(self.args.get('outputs', None), self.args)
-            for output in outputs:
+            for output in self.outputs:
                 if isinstance(output, VideoOutputData) or isinstance(output, DisplayOutputData):
                     logging.info('No --output_fps value specified for output, using default value of {}.'.format(DEFAULT_OUTPUT_FPS))
                     break

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -115,7 +115,8 @@ def test_e2e_image_blur_image_threshold(test_input=image_input, test_output=imag
 
 
 def test_e2e_video_blur_video_fps(test_input=video_input, test_output=video_output):
-    run(['blur', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--fps', '2'])
+    run(['blur', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--output_fps', '2'])
+    run(['blur', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--input_fps', '2'])
 
 
 def test_e2e_image_blur_image_window(test_input=image_input, test_output='window'):

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -114,7 +114,8 @@ def test_e2e_image_draw_image_threshold(test_input=image_input, test_output=imag
 
 
 def test_e2e_video_draw_video_fps(test_input=video_input, test_output=video_output):
-    run(['draw', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--fps', '2'])
+    run(['draw', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--output_fps', '2'])
+    run(['draw', '-i', test_input, '-o', test_output, '-r', 'fashion-v4', '--input_fps', '2'])
 
 
 def test_e2e_image_draw_image_window(test_input=image_input, test_output='window'):


### PR DESCRIPTION
The retained behavior is the following:
- If an `fps` argument is provided:
    - Input: the frame are extracted according to the `fps` value.
    - Output: the video is reconstructed according to the `fps` value.
- If not `fps` argument is provided:
    - If the input is a video, its `fps` value is used.
    - If the input is not a video, the `DEFAULT_FPS` value is used (for instance when outputing a video from images).