### PR TITLE
Reuse prediction for draw and infer

### DIFF
--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -62,7 +62,7 @@ def argparser_init():
 
     for parser in [draw_parser, blur_parser]:
         parser.add_argument('-F', '--fullscreen', help="Fullscreen if window output.", action="store_true")
-        parser.add_argument('-J', '--predict_from_json', help="Uses prediction from a Vulcan or Studio JSON.", action="store_true")
+        parser.add_argument('--from_file', dest='pred_from_file', help="Uses prediction from a Vulcan or Studio JSON.", action="store_true")
 
     draw_parser.add_argument('-S', '--draw_scores', help="Overlays the prediction scores.", action="store_true")
     draw_parser.add_argument('-L', '--draw_labels', help="Overlays the prediction labels.", action="store_true")

--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -62,7 +62,7 @@ def argparser_init():
 
     for parser in [draw_parser, blur_parser]:
         parser.add_argument('-F', '--fullscreen', help="Fullscreen if window output.", action="store_true")
-        parser.add_argument('--from_file', dest='pred_from_file', help="Uses prediction from a Vulcan or Studio JSON.", action="store_true")
+        parser.add_argument('--from_file', type=str, dest='pred_from_file', help="Uses prediction from a Vulcan or Studio JSON.")
 
     draw_parser.add_argument('-S', '--draw_scores', help="Overlays the prediction scores.", action="store_true")
     draw_parser.add_argument('-L', '--draw_labels', help="Overlays the prediction labels.", action="store_true")

--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -62,6 +62,7 @@ def argparser_init():
 
     for parser in [draw_parser, blur_parser]:
         parser.add_argument('-F', '--fullscreen', help="Fullscreen if window output.", action="store_true")
+        parser.add_argument('-J', '--predict_from_json', help="Uses prediction from a Vulcan or Studio JSON.", action="store_true")
 
     draw_parser.add_argument('-S', '--draw_scores', help="Overlays the prediction scores.", action="store_true")
     draw_parser.add_argument('-L', '--draw_labels', help="Overlays the prediction labels.", action="store_true")

--- a/deepomatic/cli/cmds/feedback.py
+++ b/deepomatic/cli/cmds/feedback.py
@@ -99,8 +99,12 @@ def main(args):
     ]
 
     # Start uploading
-    loop = MainLoop(pools, [queue], pbar)
-    loop.run_forever()
+    loop = MainLoop(pools, [queue], pbar, exit_event)
+    try:
+        stop_asked = loop.run_forever()
+    except Exception:
+        loop.cleanup()
+        raise
 
     # If the process encountered an error, the exit code is 1.
     # If the process is interrupted using SIGINT (ctrl + C) or SIGTERM, the threads are stopped, and

--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -155,7 +155,7 @@ class SendInferenceGreenlet(thread_base.Greenlet):
         self.workflow.close_client(self.push_client)
 
     def process_msg(self, frame):
-        frame.inference_async_result = self.workflow.infer(frame.buf_bytes, self.push_client)
+        frame.inference_async_result = self.workflow.infer(frame.buf_bytes, self.push_client, frame.name)
         return frame
 
 

--- a/deepomatic/cli/cmds/studio_helpers/vulcan2studio.py
+++ b/deepomatic/cli/cmds/studio_helpers/vulcan2studio.py
@@ -1,44 +1,47 @@
 
-def transform_json_from_vulcan_to_studio(vulcan_json, name, filename):
+def transform_json_from_vulcan_to_studio(vulcan_json):
     """Transforms a json from the vulcan format to the Studio format."""
     # Initialize variables
     studio_json = {'tags': [], 'images': []}
     unique_tags = set()
 
-    # Loop through all images
-    img_studio = {'annotated_regions': []}
-    all_predictions = vulcan_json['outputs'][0]['labels']['predicted']
-    for prediction in all_predictions:
-        # Build studio annotation
-        annotation = {
-            "tags": [prediction['label_name']],
-            "region_type": "Whole",
-            "score": prediction['score'],
-            "threshold": prediction['threshold']
-        }
+    # Transform vulcan json to a list of vulcan json if needed
+    if isinstance(vulcan_json, dict):
+        vulcan_json = [vulcan_json]
 
-        # Add bounding box
-        if 'roi' in prediction:
-            annotation['region_type'] = 'Box'
-            annotation['region'] = {
-                "xmin": prediction['roi']['bbox']['xmin'],
-                "xmax": prediction['roi']['bbox']['xmax'],
-                "ymin": prediction['roi']['bbox']['ymin'],
-                "ymax": prediction['roi']['bbox']['ymax']
+    # Loop through all vulcan images
+    for vulcan_image in vulcan_json:
+        # Initialize studio images
+        studio_image = {'annotated_regions': []}
+
+        # Loop through all vulcan predictions
+        for prediction in vulcan_image['outputs'][0]['labels']['predicted']:
+            # Build studio annotation in case of classification or tagging
+            annotation = {
+                "tags": [prediction['label_name']],
+                "region_type": "Whole",
+                "score": prediction['score'],
+                "threshold": prediction['threshold']
             }
 
-        # Update json
-        img_studio['annotated_regions'].append(annotation)
+            # Add bounding box if needed
+            if 'roi' in prediction:
+                annotation['region_type'] = 'Box'
+                annotation['region'] = {
+                    "xmin": prediction['roi']['bbox']['xmin'],
+                    "xmax": prediction['roi']['bbox']['xmax'],
+                    "ymin": prediction['roi']['bbox']['ymin'],
+                    "ymax": prediction['roi']['bbox']['ymax']
+                }
 
-        # Update unique tags
-        unique_tags.add(prediction['label_name'])
+            # Update json and unique tags
+            studio_image['annotated_regions'].append(annotation)
+            unique_tags.add(prediction['label_name'])
 
-    # Update json vesta
-    studio_json['images'].append(img_studio)
-    studio_json['images'][0]['location'] = name
-    studio_json['images'][0]['data'] = {'filename': filename}
+        # Update studio json
+        studio_json['images'].append(studio_image)
 
-    # Update unique tags
+    # Update final unique tags
     studio_json['tags'] = list(unique_tags)
 
     return studio_json

--- a/deepomatic/cli/cmds/studio_helpers/vulcan2studio.py
+++ b/deepomatic/cli/cmds/studio_helpers/vulcan2studio.py
@@ -12,7 +12,9 @@ def transform_json_from_vulcan_to_studio(vulcan_json):
     # Loop through all vulcan images
     for vulcan_image in vulcan_json:
         # Initialize studio images
-        studio_image = {'annotated_regions': []}
+        studio_image = {'annotated_regions': [], 'location': vulcan_image.get('location', '')}
+        if 'data' in vulcan_image:
+            studio_image['data'] = vulcan_image['data']
 
         # Loop through all vulcan predictions
         for prediction in vulcan_image['outputs'][0]['labels']['predicted']:

--- a/deepomatic/cli/cmds/studio_helpers/vulcan2studio.py
+++ b/deepomatic/cli/cmds/studio_helpers/vulcan2studio.py
@@ -59,6 +59,8 @@ def transform_json_from_studio_to_vulcan(studio_json):
     for studio_image in studio_json['images']:
         # Initialize vulcan prediction
         vulcan_pred = {'outputs': [{'labels': {'discarded': [], 'predicted': []}}]}
+        predicted = []
+        discarded = []
         for metadata in ['location', 'data']:
             if metadata in studio_image:
                 vulcan_pred[metadata] = studio_image[metadata]
@@ -85,9 +87,15 @@ def transform_json_from_studio_to_vulcan(studio_json):
 
             # Update json
             if annotation['score'] >= annotation['threshold']:
-                vulcan_pred['outputs'][0]['labels']['predicted'].append(annotation)
+                predicted.append(annotation)
             else:
-                vulcan_pred['outputs'][0]['labels']['discarded'].append(annotation)
+                discarded.append(annotation)
+
+        # Sort by prediction score of descending order
+        predicted = sorted(predicted, key=lambda k: k['score'], reverse=True)
+        discarded = sorted(discarded, key=lambda k: k['score'], reverse=True)
+        vulcan_pred['outputs'][0]['labels']['predicted'] = predicted
+        vulcan_pred['outputs'][0]['labels']['discarded'] = discarded
 
         # Update vulcan json
         vulcan_json.append(vulcan_pred)

--- a/deepomatic/cli/exceptions.py
+++ b/deepomatic/cli/exceptions.py
@@ -30,5 +30,9 @@ class DeepoFPSError(DeepoException):
     pass
 
 
-class DeepoVideoError(DeepoException):
+class DeepoVideoOpenError(DeepoException):
+    pass
+
+
+class DeepoInputError(DeepoException):
     pass

--- a/deepomatic/cli/exceptions.py
+++ b/deepomatic/cli/exceptions.py
@@ -12,3 +12,23 @@ class DeepoRPCRecognitionError(DeepoException):
 
 class DeepoCLICredentialsError(DeepoException):
     pass
+
+
+class DeepoWorkflowError(DeepoException):
+    pass
+
+
+class DeepoUnknownOutputError(DeepoException):
+    pass
+
+
+class DeepoSaveJsonToFileError(DeepoException):
+    pass
+
+
+class DeepoFPSError(DeepoException):
+    pass
+
+
+class DeepoVideoError(DeepoException):
+    pass

--- a/deepomatic/cli/exceptions.py
+++ b/deepomatic/cli/exceptions.py
@@ -36,3 +36,7 @@ class DeepoVideoOpenError(DeepoException):
 
 class DeepoInputError(DeepoException):
     pass
+
+
+class DeepoPredictionJsonError(DeepoException):
+    pass

--- a/deepomatic/cli/exceptions.py
+++ b/deepomatic/cli/exceptions.py
@@ -1,46 +1,46 @@
-class DeepoException(Exception):
+class DeepoCLIException(Exception):
     pass
 
 
-class DeepoRPCUnavailableError(DeepoException):
+class DeepoRPCUnavailableError(DeepoCLIException):
     pass
 
 
-class DeepoRPCRecognitionError(DeepoException):
+class DeepoRPCRecognitionError(DeepoCLIException):
     pass
 
 
-class DeepoCLICredentialsError(DeepoException):
+class DeepoCLICredentialsError(DeepoCLIException):
     pass
 
 
-class DeepoWorkflowError(DeepoException):
+class DeepoWorkflowError(DeepoCLIException):
     pass
 
 
-class DeepoUnknownOutputError(DeepoException):
+class DeepoUnknownOutputError(DeepoCLIException):
     pass
 
 
-class DeepoSaveJsonToFileError(DeepoException):
+class DeepoSaveJsonToFileError(DeepoCLIException):
     pass
 
 
-class DeepoOpenJsonError(DeepoException):
+class DeepoOpenJsonError(DeepoCLIException):
     pass
 
 
-class DeepoFPSError(DeepoException):
+class DeepoFPSError(DeepoCLIException):
     pass
 
 
-class DeepoVideoOpenError(DeepoException):
+class DeepoVideoOpenError(DeepoCLIException):
     pass
 
 
-class DeepoInputError(DeepoException):
+class DeepoInputError(DeepoCLIException):
     pass
 
 
-class DeepoPredictionJsonError(DeepoException):
+class DeepoPredictionJsonError(DeepoCLIException):
     pass

--- a/deepomatic/cli/exceptions.py
+++ b/deepomatic/cli/exceptions.py
@@ -26,6 +26,10 @@ class DeepoSaveJsonToFileError(DeepoException):
     pass
 
 
+class DeepoOpenJsonError(DeepoException):
+    pass
+
+
 class DeepoFPSError(DeepoException):
     pass
 

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -161,7 +161,7 @@ def input_loop(kwargs, postprocessing=None):
 
 
 class InputData(object):
-    def __init__(self, descriptor,  **kwargs):
+    def __init__(self, descriptor, **kwargs):
         self._descriptor = descriptor
         self._args = kwargs
         self._name, _ = os.path.splitext(os.path.basename(str(descriptor)))

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -452,7 +452,7 @@ class JsonInputData(InputData):
         # Go through all locations and check input validity
         self._inputs = []
         for studio_img in studio_json['images']:
-            img_location = img['location']
+            img_location = studio_img['location']
             # If the file does not exist, ignore it
             if not os.path.isfile(img_location):
                 LOGGER.warning("Could not find file {} referenced in JSON {}, skipping it".format(img_location, descriptor))

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -336,7 +336,7 @@ class VideoInputData(InputData):
         skip_ratio = 1. / (1 + self._skip_frame)
         try:
             return int(self._cap.get(cv2.CAP_PROP_FRAME_COUNT) * fps_ratio * skip_ratio)
-        except:
+        except Exception:
             LOGGER.warning('Cannot compute the total frame count')
             return 0
 
@@ -436,7 +436,7 @@ class StudioJsonInputData(InputData):
             with open(descriptor) as json_file:
                 studio_json = json.load(json_file)
             return is_valid_studio_json(studio_json)
-        except:
+        except Exception:
             return False
 
     def __init__(self, descriptor, **kwargs):

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -422,23 +422,30 @@ class JsonInputData(InputData):
         try:
             with open(descriptor) as json_file:
                 json_data = json.load(json_file)
-        except Exception:
-            raise NameError('File {} is not a valid json'.format(descriptor))
+        except:
+            LOGGER.debug('File {} is not a valid json'.format(descriptor))
+            return False
 
         # Check that the json follows the minimum Studio format
         studio_format_error = 'File {} is not a valid Studio json'.format(descriptor)
         if 'images' not in json_data:
-            raise NameError(studio_format_error)
+            LOGGER.debug(studio_format_error)
+            return False
         elif not isinstance(json_data['images'], list):
-            raise NameError(studio_format_error)
+            LOGGER.debug(studio_format_error)
+            return False
         else:
             for img in json_data['images']:
                 if not isinstance(img, dict):
-                    raise NameError(studio_format_error)
+                    LOGGER.debug(studio_format_error)
+                    return False
                 elif 'location' not in img:
-                    raise NameError(studio_format_error)
+                    LOGGER.debug(studio_format_error)
+                    return False
                 elif not ImageInputData.is_valid(img['location']):
-                    raise NameError('File {} is not valid'.format(img['location']))
+                    LOGGER.debug('File {} is not valid'.format(img['location']))
+                    return False
+
         return True
 
     def __init__(self, descriptor, **kwargs):

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -35,11 +35,11 @@ def get_input(descriptor, kwargs):
                 LOGGER.debug('Video input data detected for {}'.format(descriptor))
                 return VideoInputData(descriptor, **kwargs)
             # Studio json containing images location
-            elif not kwargs['predict_from_json'] and ImagesLocationStudioJsonInputData.is_valid(descriptor):
+            elif not kwargs['pred_from_file'] and ImagesLocationStudioJsonInputData.is_valid(descriptor):
                 LOGGER.debug('Image location studio json input data detected for {}'.format(descriptor))
                 return ImagesLocationStudioJsonInputData(descriptor, **kwargs)
             # Studio or vulcan json containing images location and predictions
-            elif kwargs['predict_from_json'] and ImagesPredictionJsonInputData.is_valid(descriptor):
+            elif kwargs['pred_from_file'] and ImagesPredictionJsonInputData.is_valid(descriptor):
                 LOGGER.debug('Image prediction json input data detected for {}'.format(descriptor))
                 return ImagesPredictionJsonInputData(descriptor, **kwargs)
             else:
@@ -374,10 +374,10 @@ class DirectoryInputData(InputData):
                 elif VideoInputData.is_valid(path):
                     LOGGER.debug('Video input data detected for {}'.format(path))
                     self._inputs.append(VideoInputData(path, **kwargs))
-                elif not kwargs['predict_from_json'] and ImagesLocationStudioJsonInputData.is_valid(path):
+                elif not kwargs['pred_from_file'] and ImagesLocationStudioJsonInputData.is_valid(path):
                     LOGGER.debug('Image location studio json input data detected for {}'.format(path))
                     self._inputs.append(ImagesLocationStudioJsonInputData(path, **kwargs))
-                elif kwargs['predict_from_json'] and ImagesPredictionJsonInputData.is_valid(path):
+                elif kwargs['pred_from_file'] and ImagesPredictionJsonInputData.is_valid(path):
                     LOGGER.debug('Image prediction json input data detected for {}'.format(path))
                     self._inputs.append(ImagesPredictionJsonInputData(path, **kwargs))
                 elif self._recursive and self.is_valid(path):

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -321,16 +321,15 @@ class VideoInputData(InputData):
             raise DeepoFPSError('Null fps detected for video {}, please specify it with --input_fps option.'.format(self._descriptor))
 
         # Compute fps for frame extraction so that we don't analyze useless frame that will be discarded later
-        if self._extract_fps == None:  # ensures we compute it only once
-            if not self._kwargs_fps:
-                self._extract_fps = self._video_fps
-                LOGGER.debug('No --input_fps specified, using raw video fps of {}'.format(self._video_fps))
-            elif self._kwargs_fps < self._video_fps:
-                self._extract_fps = self._kwargs_fps
-                LOGGER.debug('Using user-specified --input_fps of {} instead of raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
-            else:
-                self._extract_fps = self._video_fps
-                LOGGER.debug('User-specified --input_fps of {} specified but using maximum raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
+        if not self._kwargs_fps:
+            self._extract_fps = self._video_fps
+            LOGGER.debug('No --input_fps specified, using raw video fps of {}'.format(self._video_fps))
+        elif self._kwargs_fps < self._video_fps:
+            self._extract_fps = self._kwargs_fps
+            LOGGER.debug('Using user-specified --input_fps of {} instead of raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
+        else:
+            self._extract_fps = self._video_fps
+            LOGGER.debug('User-specified --input_fps of {} specified but using maximum raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
 
         return self._extract_fps
 

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -227,6 +227,7 @@ class VideoInputData(InputData):
 
     def __init__(self, descriptor, **kwargs):
         super(VideoInputData, self).__init__(descriptor, **kwargs)
+        self._i = 0
         self._name = '%s_%s_%s' % (self._name, '%05d', self._reco)
         self._cap = None
         self._open_video()
@@ -249,6 +250,7 @@ class VideoInputData(InputData):
 
     def __iter__(self):
         self._open_video()
+        self._i = 0
         self._frames_to_skip = 0
         self._should_skip_fps = self._video_fps
         return self

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -227,7 +227,6 @@ class VideoInputData(InputData):
 
     def __init__(self, descriptor, **kwargs):
         super(VideoInputData, self).__init__(descriptor, **kwargs)
-        self._i = 0
         self._name = '%s_%s_%s' % (self._name, '%05d', self._reco)
         self._cap = None
         self._open_video()
@@ -250,7 +249,6 @@ class VideoInputData(InputData):
 
     def __iter__(self):
         self._open_video()
-        self._i = 0
         self._frames_to_skip = 0
         self._should_skip_fps = self._video_fps
         return self
@@ -358,7 +356,6 @@ class DirectoryInputData(InputData):
         self._current = None
         self._files = []
         self._inputs = []
-        self._i = 0
         self._recursive = self._args['recursive']
 
         if self.is_valid(descriptor):
@@ -381,12 +378,10 @@ class DirectoryInputData(InputData):
     def _gen(self):
         for source in self._inputs:
             for frame in source:
-                self._i += 1
                 yield frame
 
     def __iter__(self):
         self.gen = self._gen()
-        self._i = 0
         return self
 
     def __next__(self):

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -209,6 +209,7 @@ class VideoInputData(InputData):
         self._open_video()
         self._kwargs_fps = kwargs['input_fps']
         self._skip_frame = kwargs['skip_frame']
+        self._extract_fps = None
         self._fps = self.get_fps()
 
     def _open_video(self, raise_exc=True):
@@ -296,15 +297,16 @@ class VideoInputData(InputData):
             raise ValueError('Null fps detected for video {}, please specify it with --input_fps option.'.format(self._descriptor))
 
         # Compute fps for frame extraction so that we don't analyze useless frame that will be discarded later
-        if not self._kwargs_fps:
-            self._extract_fps = self._video_fps
-            LOGGER.info('No --input_fps specified, using raw video fps of {}'.format(self._video_fps))
-        elif self._kwargs_fps < self._video_fps:
-            self._extract_fps = self._kwargs_fps
-            LOGGER.info('Using user-specified --input_fps of {} instead of raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
-        else:
-            self._extract_fps = self._video_fps
-            LOGGER.info('User-specified --input_fps of {} specified but using maximum raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
+        if self._extract_fps == None:  # ensures we compute it only once
+            if not self._kwargs_fps:
+                self._extract_fps = self._video_fps
+                LOGGER.debug('No --input_fps specified, using raw video fps of {}'.format(self._video_fps))
+            elif self._kwargs_fps < self._video_fps:
+                self._extract_fps = self._kwargs_fps
+                LOGGER.debug('Using user-specified --input_fps of {} instead of raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
+            else:
+                self._extract_fps = self._video_fps
+                LOGGER.debug('User-specified --input_fps of {} specified but using maximum raw video fps of {}'.format(self._kwargs_fps, self._video_fps))
 
         return self._extract_fps
 

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -4,7 +4,7 @@ import sys
 import json
 import logging
 import threading
-from .json_schema import validate_studio_json, validate_vulcan_json
+from .json_schema import is_valid_studio_json, is_valid_vulcan_json
 from .exceptions import DeepoCLICredentialsError
 from .thread_base import Pool, Thread, MainLoop, CurrentMessages, blocking_lock, QUEUE_MAX_SIZE
 from .cmds.infer import SendInferenceGreenlet, ResultInferenceGreenlet, PrepareInferenceThread
@@ -436,8 +436,12 @@ class StudioJsonInputData(InputData):
 
     @classmethod
     def is_valid(cls, descriptor):
-        # Check that its a proper studio json
-        return validate_studio_json(descriptor)
+        try:
+            with open(descriptor) as json_file:
+                studio_json = json.load(json_file)
+            return is_valid_studio_json(studio_json)
+        except:
+            return False
 
     def __init__(self, descriptor, **kwargs):
         super(StudioJsonInputData, self).__init__(descriptor, **kwargs)

--- a/deepomatic/cli/json_schema.py
+++ b/deepomatic/cli/json_schema.py
@@ -1,6 +1,11 @@
+import os
 import sys
 import json
+import logging
 from jsonschema import validate
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 # Define the vulcan json schema
@@ -100,30 +105,40 @@ STUDIO_JSON_SCHEMA = {
 }
 
 
-def test_json_format(json_path):
-    """Find the proper json format."""
-    # Try to load the file as a json
+def validate_json(json_path, json_schema):
+    """Validate a JSON using a schema"""
+    # Check if the file exists
+    if not os.path.isfile(json_path):
+        LOGGER.error('File {} does not exists')
+        return False
+
+    # Load the file as a json
     try:
         with open(json_path) as json_file:
             json_data = json.load(json_file)
     except Exception as e:
-        print('File {} could not be loaded as JSON: {}'.format(json_path, e))
+        LOGGER.error('File {} could not be loaded as JSON: {}'.format(json_path, e))
         sys.exit(1)
 
-    # Test vulcan json
+    # Test json schema
     try:
-        validate(instance=json_data, schema=VULCAN_JSON_SCHEMA)
-        print('JSON {} is a valid vulcan JSON'.format(json_path))
+        validate(instance=json_data, schema=json_schema)
+        return True
     except:
-        print('JSON {} is not a valid vulcan JSON'.format(json_path))
+        return False
 
-    # Test studio json
-    try:
-        validate(instance=json_data, schema=STUDIO_JSON_SCHEMA)
-        print('JSON {} is a valid studio JSON'.format(json_path))
-    except:
-        print('JSON {} is not a valid studio JSON'.format(json_path))
+
+def validate_studio_json(json_path):
+    """Validate a JSON using the studio schema"""
+    return validate_json(json_path, STUDIO_JSON_SCHEMA)
+
+
+def validate_vulcan_json(json_path):
+    """Validate a JSON using the vulcan schema"""
+    return validate_json(json_path, VULCAN_JSON_SCHEMA)
 
 
 if __name__ == '__main__':
-    test_json_format(sys.argv[1])
+    json_path = sys.argv[1]
+    LOGGER.info("Studio json validity: {}".format(validate_studio_json(json_path)))
+    LOGGER.info("Vulcan json validity: {}".format(validate_vulcan_json(json_path)))

--- a/deepomatic/cli/json_schema.py
+++ b/deepomatic/cli/json_schema.py
@@ -10,7 +10,6 @@ LOGGER = logging.getLogger(__name__)
 
 # Define the vulcan json schema
 VULCAN_ANNOTATION_SCHEMA = {
-    "$schema": "http://json-schema.org/schema#",
     "type": "array",
     "items": {
         "type": "object",
@@ -24,7 +23,6 @@ VULCAN_ANNOTATION_SCHEMA = {
     }
 }
 VULCAN_JSON_SCHEMA = {
-    "$schema": "http://json-schema.org/schema#",
     "type": "array",
     "items": {
         "type": "object",
@@ -53,7 +51,6 @@ VULCAN_JSON_SCHEMA = {
 
 # Define the studio json format
 STUDIO_JSON_SCHEMA = {
-    "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "required": ["tags", "images"],
     "properties": {

--- a/deepomatic/cli/json_schema.py
+++ b/deepomatic/cli/json_schema.py
@@ -1,0 +1,129 @@
+import sys
+import json
+from jsonschema import validate
+
+
+# Define the vulcan json schema
+VULCAN_ANNOTATION_SCHEMA = {
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "roi": {},
+            "score": {},
+            "label_id": {},
+            "threshold": {},
+            "label_name": {}
+        }
+    }
+}
+VULCAN_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "required": ["outputs"],
+        "properties": {
+            "location": {"type": "string"},
+            "outputs": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["labels"],
+                    "properties": {
+                        "labels": {
+                            "type": "object",
+                            "properties": {
+                                "discarded": VULCAN_ANNOTATION_SCHEMA,
+                                "predicted": VULCAN_ANNOTATION_SCHEMA
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+# Define the studio json format
+STUDIO_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "required": ["tags", "images"],
+    "properties": {
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"}
+        },
+        "images": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["location", "annotated_regions"],
+                "properties": {
+                    "location": {"type": "string"},
+                    "data": {"type": "object"},
+                    "annotated_regions": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["tags", "region_type"],
+                            "properties": {
+                                "tags": {
+                                    "type": "array",
+                                    "items": {"type": "string"}
+                                },
+                                "region_type": {
+                                    "type": "string",
+                                    "enum": ["Box", "Whole"]
+                                },
+                                "score": {"type": "number"},
+                                "threshold": {"type": "number"},
+                                "region": {
+                                    "type": "object",
+                                    "required": ["xmin", "xmax", "ymin", "ymax"],
+                                    "properties": {
+                                        "xmin": {"type": "number"},
+                                        "xmax": {"type": "number"},
+                                        "ymin": {"type": "number"},
+                                        "ymax": {"type": "number"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+def test_json_format(json_path):
+    """Find the proper json format."""
+    # Try to load the file as a json
+    try:
+        with open(json_path) as json_file:
+            json_data = json.load(json_file)
+    except Exception as e:
+        print('File {} could not be loaded as JSON: {}'.format(json_path, e))
+        sys.exit(1)
+
+    # Test vulcan json
+    try:
+        validate(instance=json_data, schema=VULCAN_JSON_SCHEMA)
+        print('JSON {} is a valid vulcan JSON'.format(json_path))
+    except:
+        print('JSON {} is not a valid vulcan JSON'.format(json_path))
+
+    # Test studio json
+    try:
+        validate(instance=json_data, schema=STUDIO_JSON_SCHEMA)
+        print('JSON {} is a valid studio JSON'.format(json_path))
+    except:
+        print('JSON {} is not a valid studio JSON'.format(json_path))
+
+
+if __name__ == '__main__':
+    test_json_format(sys.argv[1])

--- a/deepomatic/cli/json_schema.py
+++ b/deepomatic/cli/json_schema.py
@@ -101,7 +101,7 @@ def is_valid_json_with_schema(json_data, json_schema):
     try:
         validate(instance=json_data, schema=json_schema)
         return True
-    except:
+    except Exception:
         return False
 
 

--- a/deepomatic/cli/json_schema.py
+++ b/deepomatic/cli/json_schema.py
@@ -118,7 +118,7 @@ def validate_json(json_path, json_schema):
             json_data = json.load(json_file)
     except Exception as e:
         LOGGER.error('File {} could not be loaded as JSON: {}'.format(json_path, e))
-        sys.exit(1)
+        return False
 
     # Test json schema
     try:

--- a/deepomatic/cli/json_schema.py
+++ b/deepomatic/cli/json_schema.py
@@ -1,11 +1,5 @@
-import os
-import sys
 import json
-import logging
 from jsonschema import validate
-
-
-LOGGER = logging.getLogger(__name__)
 
 
 # Define the vulcan json schema
@@ -102,22 +96,8 @@ STUDIO_JSON_SCHEMA = {
 }
 
 
-def validate_json(json_path, json_schema):
+def is_valid_json_with_schema(json_data, json_schema):
     """Validate a JSON using a schema"""
-    # Check if the file exists
-    if not os.path.isfile(json_path):
-        LOGGER.error('File {} does not exists')
-        return False
-
-    # Load the file as a json
-    try:
-        with open(json_path) as json_file:
-            json_data = json.load(json_file)
-    except Exception as e:
-        LOGGER.error('File {} could not be loaded as JSON: {}'.format(json_path, e))
-        return False
-
-    # Test json schema
     try:
         validate(instance=json_data, schema=json_schema)
         return True
@@ -125,17 +105,11 @@ def validate_json(json_path, json_schema):
         return False
 
 
-def validate_studio_json(json_path):
+def is_valid_studio_json(json_data):
     """Validate a JSON using the studio schema"""
-    return validate_json(json_path, STUDIO_JSON_SCHEMA)
+    return is_valid_json_with_schema(json_data, STUDIO_JSON_SCHEMA)
 
 
-def validate_vulcan_json(json_path):
+def is_valid_vulcan_json(json_data):
     """Validate a JSON using the vulcan schema"""
-    return validate_json(json_path, VULCAN_JSON_SCHEMA)
-
-
-if __name__ == '__main__':
-    json_path = sys.argv[1]
-    LOGGER.info("Studio json validity: {}".format(validate_studio_json(json_path)))
-    LOGGER.info("Vulcan json validity: {}".format(validate_vulcan_json(json_path)))
+    return is_valid_json_with_schema(json_data, VULCAN_JSON_SCHEMA)

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -29,7 +29,7 @@ def save_json_to_file(json_data, json_path):
             LOGGER.debug('Writing %s.json done' % json_path)
     except Exception:
         LOGGER.error("Could not save file {} in json format: {}".format(json_path, traceback.format_exc()))
-        raise
+        sys.exit(1)
 
     return
 
@@ -49,7 +49,8 @@ def get_output(descriptor, kwargs):
         elif descriptor == 'window':
             return DisplayOutputData(**kwargs)
         else:
-            raise NameError("Unknown output '{}'".format(descriptor))
+            LOGGER.error("Unknown output '{}'".format(descriptor))
+            sys.exit(1)
     else:
         return DisplayOutputData(**kwargs)
 

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -268,9 +268,9 @@ class JsonOutputData(OutputData):
         self._i += 1
         predictions = frame.predictions
         if self._to_studio_format:
-            predictions = transform_json_from_vulcan_to_studio(predictions,
-                                                               frame.name,
-                                                               frame.filename)
+            predictions = transform_json_from_vulcan_to_studio(predictions)
+            predictions['images'][0]['location'] = frame.name
+            predictions['images'][0]['data'] = {'filename': frame.filename}
         else:
             predictions['location'] = frame.filename
 

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -225,7 +225,7 @@ class DisplayOutputData(OutputData):
             cv2.imshow(self._window_name, frame.output_image)
             try:
                 ms = 1000 // int(self._fps)
-            except:
+            except Exception:
                 ms = 1
             if cv2.waitKey(ms) & 0xFF == ord('q'):
                 cv2.destroyAllWindows()

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -8,6 +8,7 @@ import traceback
 from .thread_base import Thread
 from .common import Empty, write_frame_to_disk, SUPPORTED_IMAGE_OUTPUT_FORMAT, SUPPORTED_VIDEO_OUTPUT_FORMAT
 from .cmds.studio_helpers.vulcan2studio import transform_json_from_vulcan_to_studio
+from .exceptions import DeepoUnknownOutputError, DeepoSaveJsonToFileError
 
 
 LOGGER = logging.getLogger(__name__)
@@ -28,8 +29,7 @@ def save_json_to_file(json_data, json_path):
             json.dump(json_data, f)
             LOGGER.debug('Writing %s.json done' % json_path)
     except Exception:
-        LOGGER.error("Could not save file {} in json format: {}".format(json_path, traceback.format_exc()))
-        sys.exit(1)
+        raise DeepoSaveJsonToFileError("Could not save file {} in json format: {}".format(json_path, traceback.format_exc()))
 
     return
 
@@ -49,8 +49,7 @@ def get_output(descriptor, kwargs):
         elif descriptor == 'window':
             return DisplayOutputData(**kwargs)
         else:
-            LOGGER.error("Unknown output '{}'".format(descriptor))
-            sys.exit(1)
+            raise DeepoUnknownOutputError("Unknown output '{}'".format(descriptor))
     else:
         return DisplayOutputData(**kwargs)
 

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -267,12 +267,10 @@ class JsonOutputData(OutputData):
     def output_frame(self, frame):
         self._i += 1
         predictions = frame.predictions
+        predictions['location'] = frame.name
+        predictions['data'] = {'filename': frame.filename}
         if self._to_studio_format:
             predictions = transform_json_from_vulcan_to_studio(predictions)
-            predictions['images'][0]['location'] = frame.name
-            predictions['images'][0]['data'] = {'filename': frame.filename}
-        else:
-            predictions['location'] = frame.filename
 
         if self._all_predictions is not None:
             # If the json is not a wildcard we store prediction to write then to file a the end in close()

--- a/deepomatic/cli/version.py
+++ b/deepomatic/cli/version.py
@@ -1,6 +1,6 @@
 __title__ = 'deepomatic-cli'
 __description__ = 'Deepomatic CLI'
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 __author__ = 'deepomatic'
 __author_email__ = 'support@deepomatic.com'
 __url__ = 'https://github.com/Deepomatic/deepocli'

--- a/deepomatic/cli/workflow/__init__.py
+++ b/deepomatic/cli/workflow/__init__.py
@@ -2,6 +2,7 @@ import logging
 from .cloud_workflow import CloudRecognition
 from .rpc_workflow import RpcRecognition
 from .json_workflow import JsonRecognition
+from ..exceptions import DeepoWorkflowError
 
 
 LOGGER = logging.getLogger(__name__)
@@ -24,5 +25,5 @@ def get_workflow(args):
     elif recognition_id:
         LOGGER.debug('Using Cloud workflow with recognition_id {}'.format(recognition_id))
         return CloudRecognition(recognition_id)
-    LOGGER.error("Couldn't get workflow based on args {}".format(args))
-    sys.exit(1)
+    else:
+        DeepoWorkflowError("Couldn't get workflow based on args {}".format(args))

--- a/deepomatic/cli/workflow/__init__.py
+++ b/deepomatic/cli/workflow/__init__.py
@@ -17,7 +17,7 @@ def get_workflow(args):
     # Check whether we should use predictions from a json, rpc deployment or the cloud API
     if pred_from_file:
         LOGGER.debug('Using JSON workflow with recognition_id {}'.format(recognition_id))
-        return JsonRecognition(recognition_id)
+        return JsonRecognition(recognition_id, pred_from_file)
     elif all([recognition_id, amqp_url, routing_key]):
         LOGGER.debug('Using RPC workflow with recognition_id {}, amqp_url {} and routing_key {}'.format(recognition_id, amqp_url, routing_key))
         return RpcRecognition(recognition_id, amqp_url, routing_key)

--- a/deepomatic/cli/workflow/__init__.py
+++ b/deepomatic/cli/workflow/__init__.py
@@ -12,10 +12,10 @@ def get_workflow(args):
     recognition_id = args.get('recognition_id')
     amqp_url = args.get('amqp_url')
     routing_key = args.get('routing_key')
-    predict_from_json = args.get('predict_from_json')
+    pred_from_file = args.get('pred_from_file')
 
     # Check whether we should use predictions from a json, rpc deployment or the cloud API
-    if predict_from_json:
+    if pred_from_file:
         LOGGER.debug('Using JSON workflow with recognition_id {}'.format(recognition_id))
         return JsonRecognition(recognition_id)
     elif all([recognition_id, amqp_url, routing_key]):

--- a/deepomatic/cli/workflow/__init__.py
+++ b/deepomatic/cli/workflow/__init__.py
@@ -1,14 +1,27 @@
+import logging
 from .cloud_workflow import CloudRecognition
 from .rpc_workflow import RpcRecognition
+from .json_workflow import JsonRecognition
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def get_workflow(args):
-    recognition_id = args['recognition_id']
+    # Retrieve recognition arguments
+    recognition_id = args.get('recognition_id')
     amqp_url = args.get('amqp_url')
     routing_key = args.get('routing_key')
+    predict_from_json = args.get('predict_from_json')
 
-    if all([recognition_id, amqp_url, routing_key]):
+    # Check whether we should use predictions from a json, rpc deployment or the cloud API
+    if predict_from_json:
+        LOGGER.debug('Using JSON workflow with recognition_id {}'.format(recognition_id))
+        return JsonRecognition(recognition_id)
+    elif all([recognition_id, amqp_url, routing_key]):
+        LOGGER.debug('Using RPC workflow with recognition_id {}, amqp_url {} and routing_key {}'.format(recognition_id, amqp_url, routing_key))
         return RpcRecognition(recognition_id, amqp_url, routing_key)
     elif recognition_id:
+        LOGGER.debug('Using Cloud workflow with recognition_id {}'.format(recognition_id))
         return CloudRecognition(recognition_id)
     raise Exception("Couldn't get workflow based on args {}".format(args))

--- a/deepomatic/cli/workflow/__init__.py
+++ b/deepomatic/cli/workflow/__init__.py
@@ -24,4 +24,5 @@ def get_workflow(args):
     elif recognition_id:
         LOGGER.debug('Using Cloud workflow with recognition_id {}'.format(recognition_id))
         return CloudRecognition(recognition_id)
-    raise Exception("Couldn't get workflow based on args {}".format(args))
+    LOGGER.error("Couldn't get workflow based on args {}".format(args))
+    sys.exit(1)

--- a/deepomatic/cli/workflow/cloud_workflow.py
+++ b/deepomatic/cli/workflow/cloud_workflow.py
@@ -6,7 +6,7 @@ from .. import common, exceptions
 import deepomatic.api.client
 import deepomatic.api.inputs
 from ..version import __title__, __version__
-from deepomatic.api.exceptions import TaskError, TaskTimeout, BadStatus
+from deepomatic.api.exceptions import TaskError, TaskTimeout
 
 LOGGER = logging.getLogger(__name__)
 
@@ -48,17 +48,9 @@ class CloudRecognition(AbstractWorkflow):
             self._model = self._client.RecognitionVersion.retrieve(recognition_version_id)
 
     def infer(self, encoded_image_bytes, _useless_push_client, _useless_frame_name):
-        # _useless_push_client and _useless_frame_name are used for the rpc and json workflos
-        try:
-            return self.InferResult(self._model.inference(
-                inputs=[deepomatic.api.inputs.ImageInput(encoded_image_bytes, encoding="binary")],
-                show_discarded=True,
-                return_task=True,
-                wait_task=False)
-            )
-        except BadStatus as e:
-            LOGGER.error('Bad status, you might not have the proper credentials: {}'.format(e))
-            sys.exit(1)
-        except Exception as e:
-            LOGGER.error(e)
-            sys.exit(1)
+        # _useless_push_client and _useless_frame_name are used for the rpc and json workflows
+        return self.InferResult(self._model.inference(
+            inputs=[deepomatic.api.inputs.ImageInput(encoded_image_bytes, encoding="binary")],
+            show_discarded=True,
+            return_task=True,
+            wait_task=False))

--- a/deepomatic/cli/workflow/cloud_workflow.py
+++ b/deepomatic/cli/workflow/cloud_workflow.py
@@ -47,8 +47,8 @@ class CloudRecognition(AbstractWorkflow):
         if self._model is None:
             self._model = self._client.RecognitionVersion.retrieve(recognition_version_id)
 
-    def infer(self, encoded_image_bytes, _useless_push_client):
-        # push_client is only used for rpc workflow
+    def infer(self, encoded_image_bytes, _useless_push_client, _useless_frame_name):
+        # _useless_push_client and _useless_frame_name are used for the rpc and json workflos
         try:
             return self.InferResult(self._model.inference(
                 inputs=[deepomatic.api.inputs.ImageInput(encoded_image_bytes, encoding="binary")],

--- a/deepomatic/cli/workflow/json_workflow.py
+++ b/deepomatic/cli/workflow/json_workflow.py
@@ -29,7 +29,7 @@ class JsonRecognition(AbstractWorkflow):
         try:
             with open(pred_file) as json_file:
                 vulcan_json_with_pred = json.load(json_file)
-        except:
+        except Exception:
             raise DeepoOpenJsonError("Prediction JSON file {} is not a valid JSON file".format(pred_file))
 
         # Check json validity
@@ -51,7 +51,7 @@ class JsonRecognition(AbstractWorkflow):
         # _useless_encoded_image_bytes and _useless_push_client are used only for rpc and cloud workflows
         try:
             frame_pred = self._all_predictions[frame_name]
-        except:
+        except Exception:
             raise InferenceError("Could not find predictions for frame {}".format(frame_name))
 
         return self.InferResult(frame_name, frame_pred)

--- a/deepomatic/cli/workflow/json_workflow.py
+++ b/deepomatic/cli/workflow/json_workflow.py
@@ -4,7 +4,7 @@ import logging
 from .workflow_abstraction import AbstractWorkflow, InferenceError
 from ..json_schema import validate_studio_json, validate_vulcan_json
 from ..cmds.studio_helpers.vulcan2studio import transform_json_from_studio_to_vulcan
-from ..exceptions import DeepoPredictionJsonError
+from ..exceptions import DeepoPredictionJsonError, DeepoOpenJsonError
 
 
 LOGGER = logging.getLogger(__name__)
@@ -25,18 +25,21 @@ class JsonRecognition(AbstractWorkflow):
         self._id = recognition_version_id
         self._pred_file = pred_file
 
+        # Load the json
+        try:
+            with open(pred_file) as json_file:
+                vulcan_json_with_pred = json.load(json_file)
+        except:
+            raise DeepoOpenJsonError("Prediction JSON file {} is not a valid JSON file".format(pred_file))
+
         # Check json validity
-        if not(validate_studio_json(pred_file)) and not(validate_vulcan_json(pred_file)):
-            raise DeepoPredictionJsonError("Prediction JSON file {} is neither a proper Studio or Vulcan JSON file".format(pred_file))
-        # Load json
-        with open(pred_file) as json_file:
-            vulcan_json_with_pred = json.load(json_file)
-        # Transform it to vulcan format if needed
         if validate_vulcan_json(pred_file):
             LOGGER.debug("Vulcan prediction JSON {} validated".format(pred_file))
-        if validate_studio_json(pred_file):
+        elif validate_studio_json(pred_file):
             vulcan_json_with_pred = transform_json_from_studio_to_vulcan(vulcan_json_with_pred)
             LOGGER.debug("Studio prediction JSON {} validated and transformer to Vulcan format".format(pred_file))
+        else:
+            raise DeepoPredictionJsonError("Prediction JSON file {} is neither a proper Studio or Vulcan JSON file".format(pred_file))
 
         # Store predictions for easy access
         self._all_predictions = {vulcan_pred['location']: vulcan_pred for vulcan_pred in vulcan_json_with_pred}

--- a/deepomatic/cli/workflow/json_workflow.py
+++ b/deepomatic/cli/workflow/json_workflow.py
@@ -2,7 +2,7 @@ import sys
 import json
 import logging
 from .workflow_abstraction import AbstractWorkflow, InferenceError
-from ..json_schema import validate_studio_json, validate_vulcan_json
+from ..json_schema import is_valid_studio_json, is_valid_vulcan_json
 from ..cmds.studio_helpers.vulcan2studio import transform_json_from_studio_to_vulcan
 from ..exceptions import DeepoPredictionJsonError, DeepoOpenJsonError
 
@@ -33,9 +33,9 @@ class JsonRecognition(AbstractWorkflow):
             raise DeepoOpenJsonError("Prediction JSON file {} is not a valid JSON file".format(pred_file))
 
         # Check json validity
-        if validate_vulcan_json(pred_file):
+        if is_valid_vulcan_json(pred_file):
             LOGGER.debug("Vulcan prediction JSON {} validated".format(pred_file))
-        elif validate_studio_json(pred_file):
+        elif is_valid_studio_json(pred_file):
             vulcan_json_with_pred = transform_json_from_studio_to_vulcan(vulcan_json_with_pred)
             LOGGER.debug("Studio prediction JSON {} validated and transformer to Vulcan format".format(pred_file))
         else:

--- a/deepomatic/cli/workflow/json_workflow.py
+++ b/deepomatic/cli/workflow/json_workflow.py
@@ -33,9 +33,9 @@ class JsonRecognition(AbstractWorkflow):
             raise DeepoOpenJsonError("Prediction JSON file {} is not a valid JSON file".format(pred_file))
 
         # Check json validity
-        if is_valid_vulcan_json(pred_file):
+        if is_valid_vulcan_json(vulcan_json_with_pred):
             LOGGER.debug("Vulcan prediction JSON {} validated".format(pred_file))
-        elif is_valid_studio_json(pred_file):
+        elif is_valid_studio_json(vulcan_json_with_pred):
             vulcan_json_with_pred = transform_json_from_studio_to_vulcan(vulcan_json_with_pred)
             LOGGER.debug("Studio prediction JSON {} validated and transformer to Vulcan format".format(pred_file))
         else:

--- a/deepomatic/cli/workflow/json_workflow.py
+++ b/deepomatic/cli/workflow/json_workflow.py
@@ -4,6 +4,7 @@ import logging
 from .workflow_abstraction import AbstractWorkflow, InferenceError
 from ..json_schema import validate_studio_json, validate_vulcan_json
 from ..cmds.studio_helpers.vulcan2studio import transform_json_from_studio_to_vulcan
+from ..exceptions import DeepoPredictionJsonError
 
 
 LOGGER = logging.getLogger(__name__)
@@ -26,7 +27,7 @@ class JsonRecognition(AbstractWorkflow):
 
         # Check json validity
         if not(validate_studio_json(pred_file)) and not(validate_vulcan_json(pred_file)):
-            LOGGER.error("Prediction JSON file {} is neither a proper Studio or Vulcan JSON file".format(pred_file))
+            raise DeepoPredictionJsonError("Prediction JSON file {} is neither a proper Studio or Vulcan JSON file".format(pred_file))
         # Load json
         with open(pred_file) as json_file:
             vulcan_json_with_pred = json.load(json_file)

--- a/deepomatic/cli/workflow/json_workflow.py
+++ b/deepomatic/cli/workflow/json_workflow.py
@@ -47,9 +47,7 @@ class JsonRecognition(AbstractWorkflow):
         # _useless_encoded_image_bytes and _useless_push_client are used only for rpc and cloud workflows
         try:
             frame_pred = self._all_predictions[frame_name]
-        except KeyError:
-            raise InferenceError("Could not find predictions for frame {}".format(frame_name))
         except:
-            raise
+            raise InferenceError("Could not find predictions for frame {}".format(frame_name))
 
         return self.InferResult(frame_name, frame_pred)

--- a/deepomatic/cli/workflow/json_workflow.py
+++ b/deepomatic/cli/workflow/json_workflow.py
@@ -1,11 +1,55 @@
-from .workflow_abstraction import AbstractWorkflow
+import sys
+import json
+import logging
+from .workflow_abstraction import AbstractWorkflow, InferenceError
+from ..json_schema import validate_studio_json, validate_vulcan_json
+from ..cmds.studio_helpers.vulcan2studio import transform_json_from_studio_to_vulcan
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class JsonRecognition(AbstractWorkflow):
 
-    def __init__(self, recognition_version_id):
+    class InferResult(AbstractWorkflow.AbstractInferResult):
+        def __init__(self, frame_name, frame_pred):
+            self.frame_name = frame_name
+            self.frame_pred = frame_pred
+
+        def get_predictions(self, timeout):
+            return self.frame_pred
+
+    def __init__(self, recognition_version_id, pred_file):
         super(JsonRecognition, self).__init__('r{}'.format(recognition_version_id))
         self._id = recognition_version_id
+        self._pred_file = pred_file
+
+        # Check json validity
+        if not(validate_studio_json(pred_file)) and not(validate_vulcan_json(pred_file)):
+            LOGGER.error("Prediction JSON file {} is neither a proper Studio or Vulcan JSON file".format(pred_file))
+        # Load json
+        with open(pred_file) as json_file:
+            vulcan_json_with_pred = json.load(json_file)
+        # Transform it to vulcan format if needed
+        if validate_vulcan_json(pred_file):
+            LOGGER.debug("Vulcan prediction JSON {} validated".format(pred_file))
+        if validate_studio_json(pred_file):
+            vulcan_json_with_pred = transform_json_from_studio_to_vulcan(vulcan_json_with_pred)
+            LOGGER.debug("Studio prediction JSON {} validated and transformer to Vulcan format".format(pred_file))
+
+        # Store predictions for easy access
+        self._all_predictions = {vulcan_pred['location']: vulcan_pred for vulcan_pred in vulcan_json_with_pred}
 
     def close(self):
         pass
+
+    def infer(self, _useless_encoded_image_bytes, _useless_push_client, frame_name):
+        # _useless_encoded_image_bytes and _useless_push_client are used only for rpc and cloud workflows
+        try:
+            frame_pred = self._all_predictions[frame_name]
+        except KeyError:
+            raise InferenceError("Could not find predictions for frame {}".format(frame_name))
+        except:
+            raise
+
+        return self.InferResult(frame_name, frame_pred)

--- a/deepomatic/cli/workflow/json_workflow.py
+++ b/deepomatic/cli/workflow/json_workflow.py
@@ -1,0 +1,11 @@
+from .workflow_abstraction import AbstractWorkflow
+
+
+class JsonRecognition(AbstractWorkflow):
+
+    def __init__(self, recognition_version_id):
+        super(JsonRecognition, self).__init__('r{}'.format(recognition_version_id))
+        self._id = recognition_version_id
+
+    def close(self):
+        pass

--- a/deepomatic/cli/workflow/rpc_workflow.py
+++ b/deepomatic/cli/workflow/rpc_workflow.py
@@ -85,7 +85,8 @@ class RpcRecognition(AbstractWorkflow):
             self._consume_client.remove_consuming_queue(self._response_queue, self._consumer)
         self.close_client(self._consume_client)
 
-    def infer(self, encoded_image_bytes, push_client):
+    def infer(self, encoded_image_bytes, push_client, _useless_frame_name):
+        # _useless_frame_name is used for the json workflow
         image_input = v07_ImageInput(source=BINARY_IMAGE_PREFIX + encoded_image_bytes)
         # forward_to parameter can be removed for images of worker nn with tag >= 0.7.8
         reply_to = self._response_queue.name

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests>=2.19.0,<3  # will not work below in python3
 deepomatic-api==0.8.2
 text-unidecode==1.2
 gevent==1.4.0
+jsonschema==3.0.1

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -7,7 +7,7 @@ from utils import (init_files_setup, run_cmd, IMAGE_OUTPUT, VIDEO_OUTPUT,
 
 
 # Input to test: Image, Video, Directory, Json
-IMAGE_INPUT, VIDEO_INPUT, DIRECTORY_INPUT, JSON_INPUT = init_files_setup()
+IMAGE_INPUT, VIDEO_INPUT, DIRECTORY_INPUT, JSON_INPUT, OFFLINE_PRED = init_files_setup()
 
 
 def run_blur(*args, **kwargs):
@@ -121,3 +121,7 @@ def test_e2e_image_blur_image_method_and_strenght():
 
 def test_e2e_image_blur_json_studio():
     run_blur(IMAGE_INPUT, [JSON_OUTPUT], expect_nb_json=1, studio_format=True, extra_opts=['--studio_format'])
+
+
+def test_e2e_image_blur_from_file():
+    run_blur(VIDEO_INPUT, [VIDEO_OUTPUT], expect_nb_video=1, extra_opts=['--from_file', OFFLINE_PRED])

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -7,7 +7,7 @@ from utils import (init_files_setup, run_cmd, IMAGE_OUTPUT, VIDEO_OUTPUT,
 
 
 # Input to test: Image, Video, Directory, Json
-IMAGE_INPUT, VIDEO_INPUT, DIRECTORY_INPUT, JSON_INPUT = init_files_setup()
+IMAGE_INPUT, VIDEO_INPUT, DIRECTORY_INPUT, JSON_INPUT, OFFLINE_PRED = init_files_setup()
 
 
 def run_draw(*args, **kwargs):
@@ -121,3 +121,6 @@ def test_e2e_image_draw_image_scores_and_labels():
 
 def test_e2e_image_draw_json_studio():
     run_draw(IMAGE_INPUT, [JSON_OUTPUT], expect_nb_json=1, studio_format=True, extra_opts=['--studio_format'])
+
+def test_e2e_image_draw_from_file():
+    run_draw(VIDEO_INPUT, [VIDEO_OUTPUT], expect_nb_video=1, extra_opts=['--from_file', OFFLINE_PRED])

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -6,7 +6,7 @@ from utils import init_files_setup
 
 
 # Input to test: Image, Directory, Json
-IMAGE_INPUT, VIDEO_INPUT, DIRECTORY_INPUT, JSON_INPUT = init_files_setup()
+IMAGE_INPUT, VIDEO_INPUT, DIRECTORY_INPUT, JSON_INPUT, _ = init_files_setup()
 TEST_DATASET = 'deepocli-feedback-test-detection'
 TEST_ORG = 'travis-deepocli'
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -7,7 +7,7 @@ from utils import (init_files_setup, run_cmd, IMAGE_OUTPUT, VIDEO_OUTPUT,
 
 
 # Input to test: Image, Video, Directory, Json
-IMAGE_INPUT, VIDEO_INPUT, DIRECTORY_INPUT, JSON_INPUT = init_files_setup()
+IMAGE_INPUT, VIDEO_INPUT, DIRECTORY_INPUT, JSON_INPUT, _ = init_files_setup()
 
 
 def run_infer(*args, **kwargs):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -110,6 +110,7 @@ def init_files_setup():
     img2_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/images/test.jpg', 'img_dir/img2.jpg')
     img3_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/images/test.jpg', 'img_dir/subdir/img3.jpg')
     json_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/json/studio.json', 'studio.json')
+    offline_pred_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/json/offline_pred.json', 'offline_pred.json')
     img_dir_pth = os.path.dirname(img1_pth)
 
     # Update json for path to match
@@ -119,7 +120,7 @@ def init_files_setup():
     with open(json_pth, 'w') as json_file:
         json.dump(json_data, json_file)
 
-    return single_img_pth, video_pth, img_dir_pth, json_pth
+    return single_img_pth, video_pth, img_dir_pth, json_pth, offline_pred_pth
 
 
 def run_cmd(cmds, inp, outputs, *args, **kwargs):


### PR DESCRIPTION
Adds the `--from_file` option to reuse previously computed predictions with `infer` and `blur`
```bash
deepo infer -i video.mp4 -o predictions.json -r 123
deepo blur -i video.mp4 -o video_blurred.mp4 -r 123 --from_file predictions.json
```

Also simplifies errors display and implements JSON schema for validation