### PR TITLE
Fix error message when inference timeout

### DIFF
--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -193,5 +193,5 @@ class ResultInferenceGreenlet(thread_base.Greenlet):
             LOGGER.error('Error getting predictions for frame {}: {}'.format(frame, e))
         except InferenceTimeout as e:
             self.current_messages.forget_frame(frame)
-            LOGGER.error("Couldn't get predictions for the whole batch in enough time ({} seconds). Ignoring frames {}.".format(e.timeout, self.batch))
+            LOGGER.error("Couldn't get predictions in {} seconds. Ignoring frame {}.".format(e.timeout, frame))
         return None


### PR DESCRIPTION
`self.batch` variable didn't exist.

```
[ERROR deepomatic.cli.thread_base 2019-06-28 09:19:46,395 4278 139764350072640 thread_base.py:172] Encountered an unexpected exception during main routine: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/deepomatic/cli/thread_base.py", line 170, in run
    self._run()
  File "/usr/local/lib/python2.7/dist-packages/deepomatic/cli/thread_base.py", line 159, in _run
    msg_out = self.process_msg(msg_in)
  File "/usr/local/lib/python2.7/dist-packages/deepomatic/cli/cmds/infer.py", line 196, in process_msg
    LOGGER.error("Couldn't get predictions for the whole batch in enough time ({} seconds). Ignoring frames {}.".format(e.timeout, self.batch))
AttributeError: 'ResultInferenceGreenlet' object has no attribute 'batch'
```