### PR TITLE
deepomatic-api v0.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Pillow==5.3.0
 tqdm==4.31.1
 imutils==0.5.1
 requests>=2.19.0,<3  # will not work below in python3
-deepomatic-api==0.8.2
+deepomatic-api==0.8.3
 text-unidecode==1.2
 gevent==1.4.0


### PR DESCRIPTION
Update `deepomatic-api` version from `v0.8.2` to `v0.8.3`