### PR TITLE
Add resilience to image error

### DIFF
--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -138,13 +138,13 @@ class PrepareInferenceThread(thread_base.Thread):
     def process_msg(self, frame):
         try:
             _, buf = cv2.imencode('.jpg', frame.image)
-            buf_bytes = buf.tobytes()
-            frame.buf_bytes = buf_bytes
-            self.current_messages.add_frame(frame)
-            return frame
         except Exception as e:
             LOGGER.error('Could not decode image for frame {}: {}'.format(frame, e))
-        return None
+            return None
+        buf_bytes = buf.tobytes()
+        frame.buf_bytes = buf_bytes
+        self.current_messages.add_frame(frame)
+        return frame
 
 
 class SendInferenceGreenlet(thread_base.Greenlet):

--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -136,11 +136,15 @@ class BlurImagePostprocessing(object):
 
 class PrepareInferenceThread(thread_base.Thread):
     def process_msg(self, frame):
-        _, buf = cv2.imencode('.jpg', frame.image)
-        buf_bytes = buf.tobytes()
-        frame.buf_bytes = buf_bytes
-        self.current_messages.add_frame(frame)
-        return frame
+        try:
+            _, buf = cv2.imencode('.jpg', frame.image)
+            buf_bytes = buf.tobytes()
+            frame.buf_bytes = buf_bytes
+            self.current_messages.add_frame(frame)
+            return frame
+        except Exception as e:
+            LOGGER.error('Could not decode image for frame {}: {}'.format(frame, e))
+        return None
 
 
 class SendInferenceGreenlet(thread_base.Greenlet):

--- a/deepomatic/cli/thread_base.py
+++ b/deepomatic/cli/thread_base.py
@@ -158,15 +158,7 @@ class ThreadBase(object):
                             empty = True
 
                     if self.input_queue is None or not empty:
-                        try:
-                            msg_out = self.process_msg(msg_in)
-                        except Exception as e:
-                            msg_out = None
-                            if msg_in is None:
-                                LOGGER.error("Encountered an unexpected exception during routine: {}".format(e))
-                            else:
-                                LOGGER.error("Encountered an unexpected exception during handling of frame {}, skipping it: {}".format(msg_in.name, e))
-
+                        msg_out = self.process_msg(msg_in)
                         if msg_out is not None:
                             self.put_to_output(msg_out)
             if empty:
@@ -315,9 +307,14 @@ class MainLoop(object):
         if inputs_without_error < total_inputs:
             self.pbar.update(total_inputs - inputs_without_error)
             self.pbar.close()
-            LOGGER.warning('Encountered an unexpected exception during handling of {} frames out of {}'.format(
-                total_inputs - inputs_without_error, total_inputs
-            ))
+            if self.stop_asked:
+                LOGGER.warning('Handled {} frames out of {} before stopping.'.format(
+                    total_inputs - inputs_without_error, total_inputs
+                ))
+            else:
+                LOGGER.warning('Encountered an unexpected exception during handling of {} frames out of {}.'.format(
+                    total_inputs - inputs_without_error, total_inputs
+                ))
         else:
             self.pbar.close()
         self.cleaned = True

--- a/deepomatic/cli/thread_base.py
+++ b/deepomatic/cli/thread_base.py
@@ -312,7 +312,7 @@ class MainLoop(object):
         # If needed, display the number of errors
         total_inputs = self.pbar.total
         inputs_without_error = self.pbar.n
-        if total_inputs != inputs_without_error:
+        if inputs_without_error < total_inputs:
             self.pbar.update(total_inputs - inputs_without_error)
             self.pbar.close()
             LOGGER.warning('Encountered an unexpected exception during handling of {} frames out of {}'.format(

--- a/deepomatic/cli/thread_base.py
+++ b/deepomatic/cli/thread_base.py
@@ -301,22 +301,25 @@ class MainLoop(object):
         if self.cleanup_func is not None:
             self.cleanup_func()
 
-        # If needed, display the number of errors
+        # Compute the stats on number of errors
         total_inputs = self.pbar.total
         inputs_without_error = self.pbar.n
+
+        # Update progress bar to 100% and close it
         if inputs_without_error < total_inputs:
             self.pbar.update(total_inputs - inputs_without_error)
-            self.pbar.close()
-            if self.stop_asked:
-                LOGGER.warning('Handled {} frames out of {} before stopping.'.format(
-                    total_inputs - inputs_without_error, total_inputs
-                ))
-            else:
-                LOGGER.warning('Encountered an unexpected exception during handling of {} frames out of {}.'.format(
-                    total_inputs - inputs_without_error, total_inputs
-                ))
-        else:
-            self.pbar.close()
+        self.pbar.close()
+
+        # Display errors or images stopped if needed
+        if inputs_without_error < total_inputs and self.stop_asked:
+            LOGGER.warning('Handled {} frames out of {} before stopping.'.format(
+                total_inputs - inputs_without_error, total_inputs
+            ))
+        elif inputs_without_error < total_inputs:
+            LOGGER.warning('Encountered an unexpected exception during handling of {} frames out of {}.'.format(
+                total_inputs - inputs_without_error, total_inputs
+            ))
+
         self.cleaned = True
 
     def run_forever(self):

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -124,3 +124,7 @@ def test_e2e_image_blur_json_studio():
 
 def test_e2e_image_blur_from_file():
     run_blur(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1, extra_opts=['--from_file', INPUTS['OFFLINE_PRED']])
+
+
+def test_e2e_image_corrupted_blur_image():
+    run_blur(INPUTS['IMAGE_CORRUPTED'], [OUTPUTS['IMAGE']], expect_nb_image=0)

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -124,3 +124,7 @@ def test_e2e_image_draw_json_studio():
 
 def test_e2e_image_draw_from_file():
     run_draw(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1, extra_opts=['--from_file', INPUTS['OFFLINE_PRED']])
+
+
+def test_e2e_image_corrupted_draw_image():
+    run_draw(INPUTS['IMAGE_CORRUPTED'], [OUTPUTS['IMAGE']], expect_nb_image=0)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -109,4 +109,4 @@ def test_e2e_image_infer_json_studio():
 
 
 def test_e2e_image_corrupted_infer_json():
-    run_infer(INPUTS['IMAGE_CORRUPTED'], [OUTPUTS['NO_WILDCARD_JSON']], expect_nb_json=0)
+    run_infer(INPUTS['IMAGE_CORRUPTED'], [OUTPUTS['INT_WILDCARD_JSON']], expect_nb_json=0)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -98,3 +98,7 @@ def test_e2e_image_infer_json_threshold():
 
 def test_e2e_image_infer_json_studio():
     run_infer(INPUTS['IMAGE'], [OUTPUTS['JSON']], expect_nb_json=1, studio_format=True, extra_opts=['--studio_format'])
+
+
+def test_e2e_image_corrupted_infer_json():
+    run_infer(INPUTS['IMAGE_CORRUPTED'], [OUTPUTS['JSON']], expect_nb_json=0)

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -109,4 +109,4 @@ def test_e2e_image_infer_json_studio():
 
 
 def test_e2e_image_corrupted_infer_json():
-    run_infer(INPUTS['IMAGE_CORRUPTED'], [OUTPUTS['JSON']], expect_nb_json=0)
+    run_infer(INPUTS['IMAGE_CORRUPTED'], [OUTPUTS['NO_WILDCARD_JSON']], expect_nb_json=0)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -125,6 +125,7 @@ def init_files_setup():
     │   └── subdir
     │       └── img3.jpg
     ├── single_img.jpg
+    ├── single_img_corrupted.jpg
     ├── studio.json
     └── video.mp4
     """
@@ -133,6 +134,7 @@ def init_files_setup():
 
     # Download image and video files
     single_img_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/images/test.jpg', 'single_img.jpg')
+    single_img_corrupted_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/images/test_corrupted.jpg', 'single_img_corrupted.jpg')
     video_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/videos/test.mp4', 'video.mp4')
     img_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/images/test.jpg', 'img_dir/img1.jpg')
     download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/images/test.jpg', 'img_dir/img2.jpg')
@@ -150,6 +152,7 @@ def init_files_setup():
     # Build input dictionnary for easier handling
     INPUTS = {
         'IMAGE': single_img_pth,
+        'IMAGE_CORRUPTED': single_img_corrupted_pth,
         'VIDEO': video_pth,
         'DIRECTORY': img_dir_pth,
         'STUDIO_JSON': studio_json_pth,


### PR DESCRIPTION
This PR make image error non-blocking to add resilience. For instance with 2 proper images and 1 corrupt images the result is:

```sh
$ deepo infer -i images -o img.json -r fashion-v4
[INFO 2019-07-30 16:57:31,260] Input processing:   0%|          | 0/3 [00:00<?, ?it/s]
[WARNING 2019-07-30 16:57:31,273] Cannot cast recognition ID into a number, trying with a public recognition model
libpng warning: iCCP: CRC error
libpng warning: iCCP: invalid distance too far back
libpng error: [00][02][10][80]: invalid chunk type
[ERROR 2019-07-30 16:57:31,276] Encountered an unexpected exception during handling of frame img_corrupted_fashion-v4, skipping it: OpenCV(3.4.3) /Users/travis/build/skvark/opencv-python/opencv/modules/imgcodecs/src/grfmt_base.cpp:145: error: (-10:Unknown error code -10) Raw image encoder error: Empty JPEG image (DNL not supported) in function 'throwOnEror'

[INFO 2019-07-30 16:57:32,879] Input processing:  33%|###3      | 1/3 [00:01<00:03,  1.62s/it]
[INFO 2019-07-30 16:57:33,136] Input processing:  67%|######6   | 2/3 [00:01<00:00,  1.07it/s]
[INFO 2019-07-30 16:57:33,192] Input processing: 100%|##########| 3/3 [00:01<00:00,  1.55it/s]
[WARNING 2019-07-30 16:57:33,192] Encountered an unexpected exception during handling of 1 frames out of 3
```