### PR TITLE
Fix progress information

### DIFF
--- a/deepomatic/cli/thread_base.py
+++ b/deepomatic/cli/thread_base.py
@@ -302,7 +302,8 @@ class MainLoop(object):
             self.cleanup_func()
 
         # Compute the stats on number of errors
-        total_inputs = self.pbar.total
+        # pbar total may be None for infinite streams
+        total_inputs = float('inf') if self.pbar.total is None else self.pbar.total
         inputs_without_error = self.pbar.n
 
         # Update progress bar to 100% and close it

--- a/deepomatic/cli/thread_base.py
+++ b/deepomatic/cli/thread_base.py
@@ -312,9 +312,7 @@ class MainLoop(object):
 
         # Display errors or images stopped if needed
         if inputs_without_error < total_inputs and self.stop_asked:
-            LOGGER.warning('Handled {} frames out of {} before stopping.'.format(
-                total_inputs - inputs_without_error, total_inputs
-            ))
+            LOGGER.warning('Handled {} frames out of {} before stopping.'.format(inputs_without_error, total_inputs))
         elif inputs_without_error < total_inputs:
             LOGGER.warning('Encountered an unexpected exception during handling of {} frames out of {}.'.format(
                 total_inputs - inputs_without_error, total_inputs


### PR DESCRIPTION
Before:
```sh
[WARNING 2019-08-06 23:41:52,666] Studio JSON filtered_all.json validated
[INFO 2019-08-06 23:41:53,568] Uploading images:   0%|          | 0/96775 [00:00<?, ?it/s]
[INFO 2019-08-06 23:41:59,004] Uploading images:   0%|          | 10/96775 [00:05<14:36:35,  1.84it/s]
[INFO 2019-08-06 23:41:59,128] Uploading images:   0%|          | 20/96775 [00:05<7:28:14,  3.60it/s]
[INFO 2019-08-06 23:41:59,327] Uploading images:   0%|          | 50/96775 [00:05<3:05:38,  8.68it/s]
[INFO 2019-08-06 23:41:59,816] Stop asked, waiting for threads to process queued messages.
[INFO 2019-08-06 23:42:02,311] Hard stop
[INFO 2019-08-06 23:42:04,431] Uploading images:   0%|          | 80/96775 [00:10<3:38:49,  7.36it/s]
[INFO 2019-08-06 23:42:04,702] Uploading images: 100%|##########| 96775/96775 [00:11<00:00, 8692.12it/s]
[WARNING 2019-08-06 23:42:04,703] Handled 96675 frames out of 96775 before stopping.
```

After:
```sh
[WARNING 2019-08-06 23:42:04,703] Handled 100 frames out of 96775 before stopping.
```