### PR TITLE
Reproduce minimal input directory structure

### DIFF
--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -255,12 +255,16 @@ class JsonOutputData(OutputData):
         super(JsonOutputData, self).__init__(descriptor, **kwargs)
         self._i = 0
         self._to_studio_format = kwargs.get('studio_format')
+        self._reproduce_input_dir_structure = False
 
         # Check if the output is a string wildcard
         try:
             descriptor % 'string'
             self._wildcard_type = WildCardType.STRING
             self._all_predictions = None
+            if kwargs.get('recursive', False):
+                self._reproduce_input_dir_structure = True
+                self._input_path = kwargs.get('input')
         except TypeError:
             # Check if the output is an integer wildcard
             try:
@@ -302,10 +306,25 @@ class JsonOutputData(OutputData):
                 self._all_predictions.append(predictions)
         # Otherwise we write them to file directly
         else:
+            # Build the prediction json path
             if self._wildcard_type == WildCardType.INTEGER:
                 json_path = os.path.splitext(self._descriptor % self._i)[0]
             elif self._wildcard_type == WildCardType.STRING:
-                json_path = os.path.splitext(self._descriptor % frame.name)[0]
+                if not self._reproduce_input_dir_structure:
+                    json_path = os.path.splitext(self._descriptor % frame.name)[0]
+                else:
+                    # Build the output directory with input structure
+                    output_base_dir = os.path.dirname(self._descriptor)
+                    input_rel_dir = os.path.dirname(os.path.relpath(frame.filename, self._input_path))
+                    output_full_dir = os.path.join(output_base_dir, input_rel_dir)
+
+                    # Build the final path
+                    json_file = os.path.splitext(os.path.basename(self._descriptor) % frame.name)[0]
+                    json_path = os.path.join(output_full_dir, json_file)
+
+                    # Build the json directory if it doesn't exist
+                    if output_full_dir and not os.path.isdir(output_full_dir):
+                        os.makedirs(output_full_dir)
             save_json_to_file(predictions, json_path)
 
 

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -255,7 +255,8 @@ class JsonOutputData(OutputData):
         super(JsonOutputData, self).__init__(descriptor, **kwargs)
         self._i = 0
         self._to_studio_format = kwargs.get('studio_format')
-        self._reproduce_input_dir_structure = False
+        self._preserve_input_dir_structure = False
+        self._input_path = None
 
         # Check if the output is a string wildcard
         try:
@@ -263,7 +264,7 @@ class JsonOutputData(OutputData):
             self._wildcard_type = WildCardType.STRING
             self._all_predictions = None
             if kwargs.get('recursive', False):
-                self._reproduce_input_dir_structure = True
+                self._preserve_input_dir_structure = True
                 self._input_path = kwargs.get('input')
         except TypeError:
             # Check if the output is an integer wildcard
@@ -310,7 +311,7 @@ class JsonOutputData(OutputData):
             if self._wildcard_type == WildCardType.INTEGER:
                 json_path = os.path.splitext(self._descriptor % self._i)[0]
             elif self._wildcard_type == WildCardType.STRING:
-                if not self._reproduce_input_dir_structure:
+                if not self._preserve_input_dir_structure:
                     json_path = os.path.splitext(self._descriptor % frame.name)[0]
                 else:
                     # Build the output directory with input structure

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -25,8 +25,14 @@ def run_blur(*args, **kwargs):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 3, 'expect_nb_image': 1, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 3,
+            'expect_nb_image': 1,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}
+        })
     ]
 )
 def test_e2e_image_blur(outputs, expected):
@@ -45,8 +51,14 @@ def test_e2e_image_blur(outputs, expected):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 21}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 21}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 43, 'expect_nb_image': 21, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 43,
+            'expect_nb_image': 21,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}
+        })
     ]
 )
 def test_e2e_video_blur(outputs, expected):
@@ -65,8 +77,14 @@ def test_e2e_video_blur(outputs, expected):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 2}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 2}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 5, 'expect_nb_image': 2, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 5,
+            'expect_nb_image': 2,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}
+        })
     ]
 )
 def test_e2e_directory_blur(outputs, expected):
@@ -85,8 +103,14 @@ def test_e2e_directory_blur(outputs, expected):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 3, 'expect_nb_image': 1, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 3,
+            'expect_nb_image': 1,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}
+        })
     ]
 )
 def test_e2e_json_blur(outputs, expected):

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -25,8 +25,14 @@ def run_draw(*args, **kwargs):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 3, 'expect_nb_image': 1, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 3,
+            'expect_nb_image': 1,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}
+        })
     ]
 )
 def test_e2e_image_draw(outputs, expected):
@@ -45,8 +51,14 @@ def test_e2e_image_draw(outputs, expected):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 21}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 21}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 43, 'expect_nb_image': 21, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 43,
+            'expect_nb_image': 21,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}
+        })
     ]
 )
 def test_e2e_video_draw(outputs, expected):
@@ -65,8 +77,14 @@ def test_e2e_video_draw(outputs, expected):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 2}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 2}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 5, 'expect_nb_image': 2, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 5,
+            'expect_nb_image': 2,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}
+        })
     ]
 )
 def test_e2e_directory_draw(outputs, expected):
@@ -85,8 +103,14 @@ def test_e2e_directory_draw(outputs, expected):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 3, 'expect_nb_image': 1, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 3,
+            'expect_nb_image': 1,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}
+        })
     ]
 )
 def test_e2e_json_draw(outputs, expected):

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -25,8 +25,14 @@ def run_infer(*args, **kwargs):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 3, 'expect_nb_image': 1, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 3,
+            'expect_nb_image': 1,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}
+        })
     ]
 )
 def test_e2e_image_infer(outputs, expected):
@@ -45,8 +51,14 @@ def test_e2e_image_infer(outputs, expected):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 21}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 21}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 43, 'expect_nb_image': 21, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 43,
+            'expect_nb_image': 21,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}
+        })
     ]
 )
 def test_e2e_video_infer(outputs, expected):
@@ -65,8 +77,14 @@ def test_e2e_video_infer(outputs, expected):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 2}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 2}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 5, 'expect_nb_image': 2, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 5,
+            'expect_nb_image': 2,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}
+        })
     ]
 )
 def test_e2e_directory_infer(outputs, expected):
@@ -85,8 +103,14 @@ def test_e2e_directory_infer(outputs, expected):
         ([OUTPUTS['INT_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['STR_WILDCARD_JSON']], {'expect_nb_json': 1}),
         ([OUTPUTS['NO_WILDCARD_JSON']], {'expect_nb_json': 1}),
-        ([OUTPUTS['DIR']], {'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
-        (OUTPUTS['ALL'], {'expect_nb_json': 3, 'expect_nb_image': 1, 'expect_nb_video': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}})
+        ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
+        (OUTPUTS['ALL'], {
+            'expect_nb_json': 3,
+            'expect_nb_image': 1,
+            'expect_nb_video': 1,
+            'expect_nb_subdir': 1,
+            'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}
+        })
     ]
 )
 def test_e2e_json_infer(outputs, expected):
@@ -110,3 +134,7 @@ def test_e2e_image_infer_json_studio():
 
 def test_e2e_image_corrupted_infer_json():
     run_infer(INPUTS['IMAGE_CORRUPTED'], [OUTPUTS['INT_WILDCARD_JSON']], expect_nb_json=0)
+
+
+def test_e2e_image_infer_reproduce_input_dir_struct():
+    run_infer(INPUTS['DIRECTORY'], [OUTPUTS['STR_WILDCARD_JSON']], expect_nb_json=2, expect_nb_subdir=1, extra_opts=['--recursive'])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -73,7 +73,7 @@ def check_directory(directory,
             nb_image += 1
         elif path.endswith('.mp4'):
             nb_video += 1
-        elif os.path.isdir(path):
+        elif os.path.isdir(os.path.join(directory, path)):
             nb_subdir += 1
     assert expect_nb_json == nb_json
     assert expect_nb_image == nb_image


### PR DESCRIPTION
Closes https://github.com/Deepomatic/deepocli/issues/87.

Now when using a JSON output with string wildcard `pred/%s.json` and the `--recursive` option, the minimal input directory structure is preserved to avoid collisions.

For instance:
```sh
$ tree images
images
├── img.png
└── subdir
    ├── img.png
    ├── subdir1
    │   └── img.png
    └── subdir2
        └── img.png
$ deepo infer -i images/ -o predictions/%s.json -R -r 123
$ tree predictions
predictions
├── img_123.json
└── subdir
    ├── img_123.json
    ├── subdir1
    │   └── img_123.json
    └── subdir2
        └── img_123.json