### PR TITLE
Add extension in frame name

### DIFF
--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -162,8 +162,11 @@ class InputData(object):
     def __init__(self, descriptor, **kwargs):
         self._descriptor = descriptor
         self._args = kwargs
-        self._name, _ = os.path.splitext(os.path.basename(str(descriptor)))
-        self._filename = str(descriptor)
+        self._filename = os.path.normpath(str(descriptor))
+        self._name = os.path.basename(self._filename)
+        if os.path.isfile(self._filename):
+            base, ext = os.path.splitext(self._filename)
+            self._name = '{}_{}'.format(base, ext.lstrip('.'))
         recognition_id = kwargs.get('recognition_id', '')
         self._reco = '' if recognition_id is None else recognition_id
 

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -160,12 +160,12 @@ def input_loop(kwargs, postprocessing=None):
 
 class InputData(object):
     def __init__(self, descriptor, **kwargs):
-        self._descriptor = descriptor
         self._args = kwargs
-        self._filename = os.path.normpath(str(descriptor))
-        self._name = os.path.basename(self._filename)
-        if os.path.isfile(self._filename):
-            base, ext = os.path.splitext(self._filename)
+        self._descriptor = descriptor
+        self._filename = str(descriptor)
+        self._name = os.path.basename(os.path.normpath(self._filename))
+        base, ext = os.path.splitext(self._name)
+        if ext:
             self._name = '{}_{}'.format(base, ext.lstrip('.'))
         recognition_id = kwargs.get('recognition_id', '')
         self._reco = '' if recognition_id is None else recognition_id

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -148,7 +148,7 @@ def init_files_setup():
     # Download JSON files
     vulcan_json_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/json/vulcan.json', 'vulcan.json')
     studio_json_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/json/studio.json', 'studio.json')
-    offline_pred_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/json/offline_pred.json', 'offline_pred.json')
+    offline_pred_pth = download(tmpdir, 'https://s3-eu-west-1.amazonaws.com/deepo-tests/vulcain/json/offline_pred2.json', 'offline_pred.json')
     img_dir_pth = os.path.dirname(img_pth)
 
     # Update json for path to match


### PR DESCRIPTION
Closes https://github.com/Deepomatic/deepocli/issues/91.

Adds extension in `frame.name` to avoid extension collision:
- Before two files `img.jpg` and `img.png` would get the same frame name `img_123`.
- Now the extension is taken into account resulting in `img_jpg_123` and `img_png_123`.

This also deals with `img.jpg` and `img.JPG` cases.

This breaks retrocompatibility with `--from_file` for offline predictions files but this feature has not been released on PyPi yet.