### PR TITLE
Add amqp output

### DIFF
--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -198,6 +198,7 @@ class AMQPOutputData(OutputData):
             # using pickle for now, TODO: protobuf ?
             message = pickle.dumps({
                 'frame': frame.image,
+                'buffer': frame.buf_bytes,
                 'predictions': frame.predictions,
                 'filename': frame.filename
             })


### PR DESCRIPTION
AMQP output enables easier interconnection with other programs. For now, only direct exchanges are used, the format for specifying the routing key is `-o amqp.routing_key`