### PR TITLE
Display both score and label by default

### DIFF
--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -64,11 +64,14 @@ def argparser_init():
         parser.add_argument('--from_file', type=str, dest='pred_from_file', help="Uses prediction from a Vulcan or Studio JSON.")
 
     score_group = draw_parser.add_mutually_exclusive_group()
-    score_group.add_argument('-S', '--draw_scores', help="Overlay the prediction scores. Default behavior.", action="store_true")
-    score_group.add_argument('--no_draw_scores', help="Do not overlay the prediction scores.", action="store_false")
+    score_group.add_argument('-S', '--draw_scores', dest='draw_scores', help="Overlay the prediction scores. Default behavior.", action="store_true")
+    score_group.add_argument('--no_draw_scores', dest='draw_scores', help="Do not overlay the prediction scores.", action="store_false")
+    score_group.set_defaults(draw_scores=True)
+
     label_group = draw_parser.add_mutually_exclusive_group()
-    label_group.add_argument('-L', '--draw_labels', help="Overlay the prediction labels. Default behavior.", action="store_true")
-    label_group.add_argument('--no_draw_labels', help="Do not overlay the prediction labels.", action="store_false")
+    label_group.add_argument('-L', '--draw_labels', dest='draw_labels', help="Overlay the prediction labels. Default behavior.", action="store_true")
+    label_group.add_argument('--no_draw_labels', dest='draw_labels', help="Do not overlay the prediction labels.", action="store_false")
+    label_group.set_defaults(draw_labels=True)
 
     blur_parser.add_argument('-M', '--blur_method', help="Blur method to apply, either 'pixel', 'gaussian' or 'black', defaults to 'pixel'.", default='pixel', choices=['pixel', 'gaussian', 'black'])
     blur_parser.add_argument('-B', '--blur_strength', help="Blur strength, defaults to 10.", default=10)

--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -63,8 +63,8 @@ def argparser_init():
         parser.add_argument('-F', '--fullscreen', help="Fullscreen if window output.", action="store_true")
         parser.add_argument('--from_file', type=str, dest='pred_from_file', help="Uses prediction from a Vulcan or Studio JSON.")
 
-    draw_parser.add_argument('-S', '--draw_scores', help="Overlays the prediction scores.", action="store_true")
-    draw_parser.add_argument('-L', '--draw_labels', help="Overlays the prediction labels.", action="store_true")
+    draw_parser.add_argument('-S', '--draw_scores', help="Overlays the prediction scores. Default is to display both scores and labels.", action="store_true")
+    draw_parser.add_argument('-L', '--draw_labels', help="Overlays the prediction labels. Default is to display both scores and labels.", action="store_true")
 
     blur_parser.add_argument('-M', '--blur_method', help="Blur method to apply, either 'pixel', 'gaussian' or 'black', defaults to 'pixel'.", default='pixel', choices=['pixel', 'gaussian', 'black'])
     blur_parser.add_argument('-B', '--blur_strength', help="Blur strength, defaults to 10.", default=10)

--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -63,8 +63,12 @@ def argparser_init():
         parser.add_argument('-F', '--fullscreen', help="Fullscreen if window output.", action="store_true")
         parser.add_argument('--from_file', type=str, dest='pred_from_file', help="Uses prediction from a Vulcan or Studio JSON.")
 
-    draw_parser.add_argument('-S', '--draw_scores', help="Overlays the prediction scores. Default is to display both scores and labels.", action="store_true")
-    draw_parser.add_argument('-L', '--draw_labels', help="Overlays the prediction labels. Default is to display both scores and labels.", action="store_true")
+    score_group = draw_parser.add_mutually_exclusive_group()
+    score_group.add_argument('-S', '--draw_scores', help="Overlay the prediction scores. Default behavior.", action="store_true")
+    score_group.add_argument('--no_draw_scores', help="Do not overlay the prediction scores.", action="store_false")
+    label_group = draw_parser.add_mutually_exclusive_group()
+    label_group.add_argument('-L', '--draw_labels', help="Overlay the prediction labels. Default behavior.", action="store_true")
+    label_group.add_argument('--no_draw_labels', help="Do not overlay the prediction labels.", action="store_false")
 
     blur_parser.add_argument('-M', '--blur_method', help="Blur method to apply, either 'pixel', 'gaussian' or 'black', defaults to 'pixel'.", default='pixel', choices=['pixel', 'gaussian', 'black'])
     blur_parser.add_argument('-B', '--blur_strength', help="Blur strength, defaults to 10.", default=10)

--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -32,8 +32,8 @@ def get_coordinates_from_roi(roi, width, height):
 class DrawImagePostprocessing(object):
 
     def __init__(self, **kwargs):
-        self._draw_labels = kwargs.get('draw_labels', False) or kwargs.get('no_draw_labels', True)
-        self._draw_scores = kwargs.get('draw_scores', False) or kwargs.get('no_draw_scores', True)
+        self._draw_labels = kwargs['draw_labels'] or kwargs['no_draw_labels']
+        self._draw_scores = kwargs['draw_scores'] or kwargs.['no_draw_scores']
 
     def __call__(self, frame):
         frame.output_image = frame.image.copy()

--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -33,7 +33,7 @@ class DrawImagePostprocessing(object):
 
     def __init__(self, **kwargs):
         self._draw_labels = kwargs['draw_labels'] or kwargs['no_draw_labels']
-        self._draw_scores = kwargs['draw_scores'] or kwargs.['no_draw_scores']
+        self._draw_scores = kwargs['draw_scores'] or kwargs['no_draw_scores']
 
     def __call__(self, frame):
         frame.output_image = frame.image.copy()

--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -44,14 +44,12 @@ class DrawImagePostprocessing(object):
         for pred in frame.predictions['outputs'][0]['labels']['predicted']:
             # Build legend
             label = u''
-            label_label = pred['label_name']
-            label_score = str(round(pred['score'], SCORE_DECIMAL_PRECISION))
+            if self._draw_labels:
+                label = pred['label_name']
             if self._draw_labels and self._draw_scores:
-                label = label_label + ' ' + label_score
-            elif self._draw_labels and not self._draw_scores:
-                label = label_label
-            elif self._draw_scores and not self._draw_labels:
-                label = label_score
+                label += ' '
+            if self._draw_scores:
+                label += str(round(pred['score'], SCORE_DECIMAL_PRECISION))
 
             # Make sure labels are ascii because cv2.FONT_HERSHEY_SIMPLEX doesn't support non-ascii
             label = unidecode(label)

--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -44,12 +44,16 @@ class DrawImagePostprocessing(object):
         for pred in frame.predictions['outputs'][0]['labels']['predicted']:
             # Build legend
             label = u''
-            if self._draw_labels:
-                label = pred['label_name']
+            label_label = pred['label_name']
+            label_score = str(round(pred['score'], SCORE_DECIMAL_PRECISION))
             if self._draw_labels and self._draw_scores:
-                label += ' '
-            if self._draw_scores:
-                label += str(round(pred['score'], SCORE_DECIMAL_PRECISION))
+                label = label_label + ' ' + label_score
+            elif self._draw_labels and not self._draw_scores:
+                label = label_label
+            elif self._draw_scores and not self._draw_labels:
+                label = label_score
+            else:
+                label = label_label + ' ' + label_score
             # Make sure labels are ascii because cv2.FONT_HERSHEY_SIMPLEX doesn't support non-ascii
             label = unidecode(label)
 

--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -32,8 +32,8 @@ def get_coordinates_from_roi(roi, width, height):
 class DrawImagePostprocessing(object):
 
     def __init__(self, **kwargs):
-        self._draw_labels = kwargs.get('draw_labels', False)
-        self._draw_scores = kwargs.get('draw_scores', False)
+        self._draw_labels = kwargs.get('draw_labels', False) or kwargs.get('no_draw_labels', True)
+        self._draw_scores = kwargs.get('draw_scores', False) or kwargs.get('no_draw_scores', True)
 
     def __call__(self, frame):
         frame.output_image = frame.image.copy()
@@ -52,8 +52,7 @@ class DrawImagePostprocessing(object):
                 label = label_label
             elif self._draw_scores and not self._draw_labels:
                 label = label_score
-            else:
-                label = label_label + ' ' + label_score
+
             # Make sure labels are ascii because cv2.FONT_HERSHEY_SIMPLEX doesn't support non-ascii
             label = unidecode(label)
 
@@ -87,8 +86,9 @@ class DrawImagePostprocessing(object):
                 text_corner = substract_tuple(text_corner, (x_offset, y_offset))
 
                 # Finally draw everything
-                cv2.rectangle(output_image, background_corner1, background_corner2, BACKGROUND_COLOR, -1)
-                cv2.putText(output_image, label, text_corner, cv2.FONT_HERSHEY_SIMPLEX, FONT_SCALE, TEXT_COLOR, 1)
+                if label != '':
+                    cv2.rectangle(output_image, background_corner1, background_corner2, BACKGROUND_COLOR, -1)
+                    cv2.putText(output_image, label, text_corner, cv2.FONT_HERSHEY_SIMPLEX, FONT_SCALE, TEXT_COLOR, 1)
             elif label != '':
                 # First get ideal corners
                 if tag_drawn == 0:

--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -32,8 +32,8 @@ def get_coordinates_from_roi(roi, width, height):
 class DrawImagePostprocessing(object):
 
     def __init__(self, **kwargs):
-        self._draw_labels = kwargs['draw_labels'] or kwargs['no_draw_labels']
-        self._draw_scores = kwargs['draw_scores'] or kwargs['no_draw_scores']
+        self._draw_labels = kwargs['draw_labels']
+        self._draw_scores = kwargs['draw_scores']
 
     def __call__(self, frame):
         frame.output_image = frame.image.copy()

--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -68,25 +68,25 @@ class DrawImagePostprocessing(object):
                 # Draw bounding box
                 cv2.rectangle(output_image, (xmin, ymin), (xmax, ymax), BOX_COLOR, 1)
 
-                # First get ideal corners
-                background_corner1 = (xmin, ymax + 2)
-                background_corner2 = (background_corner1[0] + ret[0], background_corner1[1] + ret[1] + baseline)
-                text_corner = (background_corner1[0], background_corner1[1] + ret[1])
-
-                # Then make sure they fit in the image
-                # For x-axis, simply shift the box to the left
-                # For y-axis, put the label at the top if it doesn't fit under the box
-                x_offset = max(0, background_corner2[0] - width + 1)
-                if background_corner2[1] > height - 1:
-                    y_offset = background_corner2[1] - ymin + 2
-                else:
-                    y_offset = 0
-                background_corner1 = substract_tuple(background_corner1, (x_offset, y_offset))
-                background_corner2 = substract_tuple(background_corner2, (x_offset, y_offset))
-                text_corner = substract_tuple(text_corner, (x_offset, y_offset))
-
-                # Finally draw everything
                 if label != '':
+                    # First get ideal corners
+                    background_corner1 = (xmin, ymax + 2)
+                    background_corner2 = (background_corner1[0] + ret[0], background_corner1[1] + ret[1] + baseline)
+                    text_corner = (background_corner1[0], background_corner1[1] + ret[1])
+
+                    # Then make sure they fit in the image
+                    # For x-axis, simply shift the box to the left
+                    # For y-axis, put the label at the top if it doesn't fit under the box
+                    x_offset = max(0, background_corner2[0] - width + 1)
+                    if background_corner2[1] > height - 1:
+                        y_offset = background_corner2[1] - ymin + 2
+                    else:
+                        y_offset = 0
+                    background_corner1 = substract_tuple(background_corner1, (x_offset, y_offset))
+                    background_corner2 = substract_tuple(background_corner2, (x_offset, y_offset))
+                    text_corner = substract_tuple(text_corner, (x_offset, y_offset))
+
+                    # Finally draw everything
                     cv2.rectangle(output_image, background_corner1, background_corner2, BACKGROUND_COLOR, -1)
                     cv2.putText(output_image, label, text_corner, cv2.FONT_HERSHEY_SIMPLEX, FONT_SCALE, TEXT_COLOR, 1)
             elif label != '':

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -142,12 +142,24 @@ def test_e2e_image_draw_image_scores():
     run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--draw_scores'])
 
 
+def test_e2e_image_draw_image_no_scores():
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--no_draw_scores'])
+
+
 def test_e2e_image_draw_image_labels():
     run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--draw_labels'])
 
 
+def test_e2e_image_draw_image_no_labels():
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--no_draw_labels'])
+
+
 def test_e2e_image_draw_image_scores_and_labels():
     run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--draw_scores', '--draw_labels'])
+
+
+def test_e2e_image_draw_image_no_scores_and_no_labels():
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--no_draw_scores', '--no_draw_labels'])
 
 
 def test_e2e_image_draw_json_studio():


### PR DESCRIPTION
Previously, if you didn't specify any of the `-L/--draw_labels` or `-S/--draw_scores` option with the `draw` command, nothing was displayed. Which is at odd with the definition of the `draw` command.

Now the default behaviour is to display both. We also introduce two new options `--no_draw_labels` and `--no_draw_scores` which are mutually exclusive with their counterpart.

This is retro compatible with the previous options.