### PR TITLE
Fix blur gaussian method

### DIFF
--- a/deepomatic/cli/cmds/infer.py
+++ b/deepomatic/cli/cmds/infer.py
@@ -123,8 +123,8 @@ class BlurImagePostprocessing(object):
                 if self._method == 'black':
                     cv2.rectangle(output_image, (xmin, ymin), (xmax, ymax), (0, 0, 0), -1)
                 elif self._method == 'gaussian':
-                    rectangle = frame[ymin:ymax, xmin:xmax]
-                    rectangle = cv2.GaussianBlur(rectangle, (15, 15), self._strength)
+                    rectangle = output_image[ymin:ymax, xmin:xmax]
+                    rectangle = cv2.GaussianBlur(rectangle, (0, 0), self._strength)
                     output_image[ymin:ymax, xmin:xmax] = rectangle
                 elif self._method == 'pixel':
                     rectangle = output_image[ymin:ymax, xmin:xmax]


### PR DESCRIPTION
Fix a bug with the blur gaussian method and correct the strength parameter.

```
$ deepo blur -i img.jpg -o blur.jpg -r 123 -M gaussian
[INFO 2019-09-06 13:54:01,300] Input processing:   0%|          | 0/1 [00:00<?, ?it/s]
[ERROR 2019-09-06 13:54:02,434] Encountered an unexpected exception during routine: Traceback (most recent call last):
  File "/Users/leo/Downloads/deepo-cli/deepomatic/cli/thread_base.py", line 172, in run
    self._run()
  File "/Users/leo/Downloads/deepo-cli/deepomatic/cli/thread_base.py", line 161, in _run
    msg_out = self.process_msg(msg_in)
  File "/Users/leo/Downloads/deepo-cli/deepomatic/cli/output_data.py", line 111, in process_msg
    self.postprocessing(frame)
  File "/Users/leo/Downloads/deepo-cli/deepomatic/cli/cmds/infer.py", line 126, in __call__
    rectangle = frame[ymin:ymax, xmin:xmax]
TypeError: 'Frame' object is not subscriptable

[INFO 2019-09-06 13:54:02,486] Input processing: 100%|##########| 1/1 [00:01<00:00,  1.19s/it]
[WARNING 2019-09-06 13:54:02,487] Encountered an unexpected exception during handling of 1 frames out of 1.
```