### PR TITLE
Implement reconnect method for streams

### DIFF
--- a/deepomatic/cli/cli_parser.py
+++ b/deepomatic/cli/cli_parser.py
@@ -38,7 +38,7 @@ def argparser_init():
     infer_parser.set_defaults(func=input_loop)
     subparsers_dict['infer'] = infer_parser
 
-   # Initialize subparser: noop
+    # Initialize subparser: noop
     help_msg = "Does nothing but reading the input and outputting it in the specified format, without predictions."
     desc_mgs = help_msg + " Typical usage is: deepo noop -i 0 -o window"
     noop_parser = subparsers.add_parser('noop', help=help_msg, description=desc_mgs)
@@ -83,13 +83,14 @@ def argparser_init():
         group.add_argument('-i', '--input', required=True, help="Input path, either an image (*{}), a video (*{}), a directory, a stream (*{}), or a Studio json (*.json). If the given path is a directory, it will recursively run inference on all the supported files in this directory if the -R option is used.".format(', *'.join(SUPPORTED_IMAGE_INPUT_FORMAT), ', *'.join(SUPPORTED_VIDEO_INPUT_FORMAT), ', *'.join(SUPPORTED_PROTOCOLS_INPUT)))
         group.add_argument('--input_fps', type=int, help="FPS used for input video frame skipping and extraction. If higher than the original video FPS, all frames will be analysed only once having the same effect as not using this parameter. If lower than the original video FPS, some frames will be discarded to simulate an input of the given FPS.", default=None)
         group.add_argument('--skip_frame', type=int, help="Number of frame to skip between two frames from the input. It can be combined with input_fps", default=0)
+        group.add_argument('--stream_reconnect', dest='stream_reconnect', help="Automatically attempt to reconnect if the video stream stops.", action="store_true")
 
     # Define output group for infer draw blur
     for cmd in ['infer', 'draw', 'blur', 'noop']:
         group = output_groups[cmd]
         group.add_argument('-o', '--outputs', required=True, nargs='+', help="Output path, either an image (*{}), a video (*{}), a json (*.json) or a directory.".format(', *'.join(SUPPORTED_IMAGE_OUTPUT_FORMAT), ', *'.join(SUPPORTED_VIDEO_OUTPUT_FORMAT)))
         group.add_argument('--output_fps', type=int, help="FPS used for output video reconstruction.", default=None)
-        
+
     # Define output group for infer draw blur
     for cmd in ['infer', 'draw', 'blur']:
         group = output_groups[cmd]


### PR DESCRIPTION
A new method to automatically reconnect to streams once they stop.

```console
$ deepo noop -i http://localhost/ISAPI/Streaming/channels/101/picture -o pred --stream_reconnect
[INFO 2019-10-17 13:33:47,053] Input fps of 25.0 automatically detected, but no output fps specified. Using same value for both.
[INFO 2019-10-17 13:33:47,068] Input processing: 0it [00:00, ?it/s]
[INFO 2019-10-17 13:33:47,359] Input processing: 2it [00:00,  6.89it/s]
[INFO 2019-10-17 13:33:47,755] Input processing: 4it [00:00,  5.83it/s]
[INFO 2019-10-17 13:33:48,207] Input processing: 6it [00:01,  5.27it/s]
[INFO 2019-10-17 13:33:48,605] Input processing: 8it [00:01,  5.21it/s]
[INFO 2019-10-17 13:33:49,051] Input processing: 10it [00:01,  5.05it/s]
[INFO 2019-10-17 13:33:49,522] Input processing: 12it [00:02,  4.89it/s]
[INFO 2019-10-17 13:33:49,990] Input processing: 14it [00:02,  4.79it/s]
^C[INFO 2019-10-17 13:33:50,097] Stop asked, waiting for threads to process queued messages.
[INFO 2019-10-17 13:33:50,305] Input processing: 15it [00:03,  4.64it/s]
[INFO 2019-10-17 13:33:50,305] Summary: errors=0 uncompleted=0 successful=15 total=inf.
```