### PR TITLE
Remove useless dependencies

### DIFF
--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -2,7 +2,6 @@ import os
 import sys
 import json
 import cv2
-import imutils
 import logging
 import traceback
 from .thread_base import Thread
@@ -209,12 +208,7 @@ class DisplayOutputData(OutputData):
 
         if self._fullscreen:
             cv2.namedWindow(self._window_name, cv2.WINDOW_NORMAL)
-            if imutils.is_cv2():
-                prop_value = cv2.cv.CV_WINDOW_FULLSCREEN
-            elif imutils.is_cv3():
-                prop_value = cv2.WINDOW_FULLSCREEN
-            else:
-                assert('Unsupported opencv version')
+            prop_value = cv2.WINDOW_FULLSCREEN
             cv2.setWindowProperty(self._window_name,
                                   cv2.WND_PROP_FULLSCREEN,
                                   prop_value)

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -30,8 +30,6 @@ def save_json_to_file(json_data, json_path):
     except Exception:
         raise DeepoSaveJsonToFileError("Could not save file {} in json format: {}".format(json_path, traceback.format_exc()))
 
-    return
-
 
 def get_output(descriptor, kwargs):
     if descriptor is not None:
@@ -365,10 +363,8 @@ class DirectoryOutputData(OutputData):
 
         # If the input is an image, then use the same extension if supported
         _, ext = os.path.splitext(frame.filename)
-        if ext.lower() in SUPPORTED_IMAGE_OUTPUT_FORMAT:
-            pass
-        # Otherwise defaults to jpg
-        else:
+        if ext.lower() not in SUPPORTED_IMAGE_OUTPUT_FORMAT:
+            # Otherwise defaults to jpg
             ext = '.jpg'
 
         # Finally write the image to file with its name

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -208,10 +208,9 @@ class DisplayOutputData(OutputData):
 
         if self._fullscreen:
             cv2.namedWindow(self._window_name, cv2.WINDOW_NORMAL)
-            prop_value = cv2.WINDOW_FULLSCREEN
             cv2.setWindowProperty(self._window_name,
                                   cv2.WND_PROP_FULLSCREEN,
-                                  prop_value)
+                                  cv2.WINDOW_FULLSCREEN)
 
     def output_frame(self, frame):
         if frame.output_image is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 opencv-python==3.4.3.18
-Pillow==5.3.0
 tqdm==4.31.1
-imutils==0.5.1
 requests>=2.19.0,<3  # will not work below in python3
 deepomatic-api==0.9.0
 text-unidecode==1.2


### PR DESCRIPTION
- pillow and imutils are not needed
- imutils was only used to detect opencv version, but since we force the opencv version in the requirements we aknow that we have opencv 3