### PR TITLE
Allow to create a non workflow app

### DIFF
--- a/deepomatic/cli/cmds/platform/app/create.py
+++ b/deepomatic/cli/cmds/platform/app/create.py
@@ -1,4 +1,3 @@
-import argparse
 from ...utils import Command, valid_path, valid_json
 from ..utils import PlatformManager
 

--- a/deepomatic/cli/cmds/platform/app/create.py
+++ b/deepomatic/cli/cmds/platform/app/create.py
@@ -1,4 +1,5 @@
-from ...utils import Command, valid_path
+import argparse
+from ...utils import Command, valid_path, valid_json
 from ..utils import PlatformManager
 
 
@@ -11,9 +12,15 @@ class CreateCommand(Command):
         parser = super(CreateCommand, self).setup(subparsers)
         parser.add_argument('-n', '--name', required=True, type=str, help="App name")
         parser.add_argument('-d', '--description', type=str, help="App description")
-        parser.add_argument('-w', '--workflow', required=True, type=valid_path, help="Path to the workflow yaml file")
+        parser.add_argument('-w', '--workflow', default=None, type=valid_path, help="Path to the workflow yaml file")
         parser.add_argument('-c', '--custom_nodes', type=valid_path, help="Path to the custom nodes python file")
+        parser.add_argument('-s', '--app_specs', default=None,
+                            type=valid_json, help="""
+                            JSON specs for the app (if workflow not provided).
+                            Example:
+                            '[{"recognition_spec_id": 123, "queue_name": "spec_123.forward"}]'
+                            """)
         return parser
 
-    def run(self, name, description, workflow, custom_nodes, **kwargs):
-        return PlatformManager().create_app(name, description, workflow, custom_nodes)
+    def run(self, name, description, workflow, custom_nodes, app_specs, **kwargs):
+        return PlatformManager().create_app(name, description, workflow, custom_nodes, app_specs)

--- a/deepomatic/cli/cmds/utils.py
+++ b/deepomatic/cli/cmds/utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import argparse
 import os
@@ -46,8 +47,15 @@ class Command(object):
 
 def valid_path(file_path):
     if not os.path.exists(file_path):
-        raise IOError("'{}' file does not exist".format(file_path))
+        raise argparse.ArgumentTypeError("'{}' file does not exist".format(file_path))
     return file_path
+
+
+def valid_json(data):
+    try:
+        return json.loads(data)
+    except Exception:
+        raise argparse.ArgumentTypeError("'{}' is not a valid JSON".format(data))
 
 
 class BuildDict(argparse.Action):

--- a/deepomatic/cli/lib/platform.py
+++ b/deepomatic/cli/lib/platform.py
@@ -23,7 +23,7 @@ class PlatformManager(object):
 
         if workflow_path:
             if app_specs is not None:
-                raise ValueError('Specs are deduced from workflow yaml, no need to specify it.')
+                raise ValueError('Specs are deduced from workflow yaml, no need to specify them.')
             ret = self.create_workflow_app(name, description, workflow_path, custom_nodes_path)
             app_id = ret['app_id']
         else:

--- a/deepomatic/cli/lib/platform.py
+++ b/deepomatic/cli/lib/platform.py
@@ -19,7 +19,7 @@ class PlatformManager(object):
     def create_app(self, name, description, workflow_path, custom_nodes_path, app_specs):
 
         if custom_nodes_path and not workflow_path:
-            raise ValueError('Custom nodes requires a workflow yaml.')
+            raise ValueError('Custom nodes require a workflow yaml.')
 
         if workflow_path:
             if app_specs is not None:

--- a/deepomatic/cli/lib/platform.py
+++ b/deepomatic/cli/lib/platform.py
@@ -16,8 +16,27 @@ class PlatformManager(object):
     def __init__(self, client_cls=HTTPHelper):
         self.client = client_cls()
 
-    def create_app(self, name, description, workflow_path, custom_nodes_path):
+    def create_app(self, name, description, workflow_path, custom_nodes_path, app_specs):
 
+        if custom_nodes_path and not workflow_path:
+            raise ValueError('Custom nodes requires a workflow yaml.')
+
+        if workflow_path:
+            if app_specs is not None:
+                raise ValueError('Specs are deduced from workflow yaml, no need to specify it.')
+            ret = self.create_workflow_app(name, description, workflow_path, custom_nodes_path)
+            app_id = ret['app_id']
+        else:
+            if app_specs is None:
+                raise ValueError('Specs are mandatory for non workflow apps.')
+            # creating an app from scratch
+            # require to add the services manually
+            data_app = {'name': name, 'desc': description, 'app_specs': app_specs}
+            ret = self.client.post('/apps', data=data_app)
+            app_id = ret['id']
+        return "New app created with id: {}".format(app_id)
+
+    def create_workflow_app(self, name, description, workflow_path, custom_nodes_path):
         with open(workflow_path, 'r') as f:
             workflow = yaml.safe_load(f)
 
@@ -39,7 +58,7 @@ class PlatformManager(object):
                     ret = self.client.post('/apps-workflow', data=data_app, files=files, content_type='multipart/mixed')
             else:
                 ret = self.client.post('/apps-workflow', data=data_app, files=files, content_type='multipart/mixed')
-            return "New app created with id: {}".format(ret['app_id'])
+            return ret
 
     def update_app(self, app_id, name, description):
         data = {}

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,3 +1,6 @@
+import pytest
+import yaml
+import json
 import os.path
 from deepomatic.cli.cli_parser import run
 from contextlib import contextmanager
@@ -61,6 +64,31 @@ class TestPlatform(object):
         args = "platform app delete --id {}".format(app_id)
         message = call_deepo(args)
         assert message == 'App{} deleted'.format(app_id)
+
+    def test_app_without_workflow(self):
+
+        args = "platform app create -n test -d abc"
+        with pytest.raises(ValueError):
+            # mandatory app specs
+            result = call_deepo(args)
+
+        with open(WORKFLOW_PATH, 'r') as f:
+            workflow = yaml.safe_load(f)
+
+        app_specs = [{
+            "queue_name": "{}.forward".format(node['name']),
+            "recognition_spec_id": node['args']['model_id']
+        } for node in workflow['workflow']['steps'] if node["type"] == "Inference"]
+
+        args = "platform app create -n test -d abc -s {}".format(json.dumps(app_specs, indent=None, separators=(',', ':')))
+        result = call_deepo(args)
+        message, app_id = result.split(':')
+        assert message == 'New app created with id'
+
+        args += ' -w ' + WORKFLOW_PATH
+        with pytest.raises(ValueError):
+            # workflow yaml and specs are exclusive
+            result = call_deepo(args)
 
     def test_appversion(self):
         with app() as app_id:


### PR DESCRIPTION
Fix #188 

Note: the app will have no services. You will need to add them by yourself with `deepo platform service create`.