### PR TITLE
WIP faster cli (notably for auto completion)

### DIFF
--- a/deepomatic/cli/__init__.py
+++ b/deepomatic/cli/__init__.py
@@ -1,5 +1,5 @@
-from gevent.monkey import patch_all
-patch_all(thread=False, time=False, subprocess=False)  # NOQA
+# from gevent.monkey import patch_all
+# patch_all(thread=False, time=False, subprocess=False)  # NOQA
 
 from .version import __version__  # NOQA
 

--- a/deepomatic/cli/cmds/studio_helpers/file.py
+++ b/deepomatic/cli/cmds/studio_helpers/file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import json
-import uuid
+#import uuid
 import logging
 from .vulcan2studio import transform_json_from_vulcan_to_studio
 from ...thread_base import Greenlet

--- a/deepomatic/cli/cmds/studio_helpers/task.py
+++ b/deepomatic/cli/cmds/studio_helpers/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import gevent
+#import gevent
 
 
 class Task(object):

--- a/deepomatic/cli/common.py
+++ b/deepomatic/cli/common.py
@@ -1,6 +1,5 @@
 import io
 import os
-import cv2
 import logging
 try:
     import Queue as queue
@@ -48,6 +47,9 @@ def write_frame_to_disk(frame, path):
         if os.path.isfile(path):
             LOGGER.warning('File {} already exists. Skipping it.'.format(path))
         else:
+            # lazy import for faster cli
+            import cv2
+
             LOGGER.debug('Writing file {} to disk'.format(path))
             cv2.imwrite(path, frame.output_image)
     else:

--- a/deepomatic/cli/input_data.py
+++ b/deepomatic/cli/input_data.py
@@ -1,5 +1,4 @@
 import os
-import cv2
 import json
 import logging
 

--- a/deepomatic/cli/json_schema.py
+++ b/deepomatic/cli/json_schema.py
@@ -1,4 +1,4 @@
-from jsonschema import validate, ValidationError
+#from jsonschema import validate, ValidationError
 
 
 class JSONSchemaType:

--- a/deepomatic/cli/lib/add_images.py
+++ b/deepomatic/cli/lib/add_images.py
@@ -4,8 +4,8 @@ import os
 import sys
 import logging
 import threading
-from tqdm import tqdm
-from deepomatic.api.http_helper import HTTPHelper
+#from tqdm import tqdm
+#from deepomatic.api.http_helper import HTTPHelper
 from deepomatic.cli.cmds.studio_helpers.file import DatasetFiles, UploadImageGreenlet
 from deepomatic.cli.cmds.studio_helpers.task import Task
 from deepomatic.cli.common import TqdmToLogger, Queue, SUPPORTED_FILE_INPUT_FORMAT

--- a/deepomatic/cli/lib/camera.py
+++ b/deepomatic/cli/lib/camera.py
@@ -1,7 +1,7 @@
 import os
 import logging
 from contextlib import contextmanager
-from deepomatic.api.http_helper import HTTPHelper
+#from deepomatic.api.http_helper import HTTPHelper
 from ..version import __title__, __version__
 
 
@@ -17,7 +17,7 @@ CLIENT = None
 ###############################################################################
 
 
-class Client(HTTPHelper):
+class Client():
     def __init__(self, **kwargs):
         super(Client, self).__init__(user_agent_prefix=DEFAULT_USER_AGENT_PREFIX,
                                      version=None, **kwargs)

--- a/deepomatic/cli/lib/inference.py
+++ b/deepomatic/cli/lib/inference.py
@@ -1,9 +1,8 @@
 import sys
-import cv2
 import logging
 import threading
 from text_unidecode import unidecode
-from tqdm import tqdm
+#from tqdm import tqdm
 
 from deepomatic.cli.common import Queue, TqdmToLogger
 from deepomatic.cli.exceptions import (DeepoCLICredentialsError,

--- a/deepomatic/cli/lib/platform.py
+++ b/deepomatic/cli/lib/platform.py
@@ -1,4 +1,4 @@
-import yaml
+#import yaml
 import logging
 
 try:
@@ -6,14 +6,14 @@ try:
 except ImportError:
     FileExistsError = OSError
 
-from deepomatic.api.http_helper import HTTPHelper
+#from deepomatic.api.http_helper import HTTPHelper
 
 
 LOGGER = logging.getLogger(__name__)
 
 
 class PlatformManager(object):
-    def __init__(self, client_cls=HTTPHelper):
+    def __init__(self):
         self.client = client_cls()
 
     def create_app(self, name, description, workflow_path, custom_nodes_path, app_specs):

--- a/deepomatic/cli/lib/site.py
+++ b/deepomatic/cli/lib/site.py
@@ -1,13 +1,11 @@
 import errno
-import requests
 import json
 import os
 import os.path
 import shutil
 import subprocess
 
-from git import Repo
-from deepomatic.api.http_helper import HTTPHelper
+#from deepomatic.api.http_helper import HTTPHelper
 
 
 DEEPOMATIC_SITE_PATH = os.path.join(os.path.expanduser('~'), '.deepomatic', 'sites')
@@ -35,7 +33,11 @@ def makedirs(folder, *args, **kwargs):
 
 
 class SiteManager(object):
-    def __init__(self, path=DEEPOMATIC_SITE_PATH, client_cls=HTTPHelper):
+    def __init__(self, path=DEEPOMATIC_SITE_PATH):
+        # lazy import for faster cli
+        import requests
+        from git import Repo
+
         makedirs(path)
         self._repo = Repo.init(path)
         self._client = client_cls()

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import json
-import cv2
 import logging
 import traceback
 from .thread_base import Thread

--- a/deepomatic/cli/thread_base.py
+++ b/deepomatic/cli/thread_base.py
@@ -1,13 +1,13 @@
 import logging
 import traceback
 import heapq
-import gevent
+#import gevent
 import signal
 from contextlib import contextmanager
-from gevent.threadpool import ThreadPool
+#from gevent.threadpool import ThreadPool
 from threading import Lock
 from .common import clear_queue, Full, Empty
-from deepomatic.api.exceptions import BadStatus
+#from deepomatic.api.exceptions import BadStatus
 from .exceptions import DeepoCLIException
 
 

--- a/deepomatic/cli/workflow/cloud_workflow.py
+++ b/deepomatic/cli/workflow/cloud_workflow.py
@@ -4,11 +4,11 @@ from ..exceptions import (SendInferenceError,
                           ResultInferenceError,
                           ResultInferenceTimeout)
 from .. import exceptions
-import deepomatic.api.client
-import deepomatic.api.inputs
+#import deepomatic.api.client
+#import deepomatic.api.inputs
 from ..version import __title__, __version__
-from tenacity import stop_never
-from deepomatic.api.exceptions import TaskError, TaskTimeout, BadStatus, DeepomaticException
+#from tenacity import stop_never
+#from deepomatic.api.exceptions import TaskError, TaskTimeout, BadStatus, DeepomaticException
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
We have a really slow cli, which makes the auto-completion from #192 unusable.

`time deepo --help` takes ~900ms; completion takes more.

This WIP PR uses `python -X importtime -c 'import deepomatic.cli.cli_parser'` to diagnostic slow imports, like in https://github.com/Deepomatic/dmake/pull/478

First non-working pass, just to find what we can gain:

- gevent monkey patch: 100ms
- jsonschema: 100ms
- cv2: large
- requests: large
- git: 50ms
- deepomatic.api: 230ms
- tenacity 40ms
- tqdm: medium
- yaml: 40ms
- uuid: 10ms

`time deepo --help`: 
python 3.6.12
- before: 950ms
- after: 550ms

python 3.8.6
- before: 830ms
- after: 170ms

autocompletion speed follows these numbers.