### PR TITLE
Raise warning not an error on unsupported files

### DIFF
--- a/deepomatic/cli/json_schema.py
+++ b/deepomatic/cli/json_schema.py
@@ -230,7 +230,3 @@ def validate_json(json_data):
     return is_valid, error, schema_type
 
 
-if __name__ == "__main__":
-    A  = {"id": None, "data": [{"file": "single_img.jpg"}], "metadata": "{\"framename\": \"single_img_fashion-v4\", \"original_filename\": \"single_img.jpg\"}", "annotations": [{"concepts": [{"name": "face", "bool": True}], "region": {"bbox": {"xmin": 0.43869650900900903, "ymin": 0.2527734375, "xmax": 0.5399892079579579, "ymax": 0.2527734375}}}, {"concepts": [{"name": "shoes", "bool": True}], "region": {"bbox": {"xmin": 0.39902402402402404, "ymin": 0.898765625, "xmax": 0.5808464714714715, "ymax": 0.9883515625}}}], "splits": ["train"]}
-    print("3B")
-    print(validate_json(A))

--- a/deepomatic/cli/json_schema.py
+++ b/deepomatic/cli/json_schema.py
@@ -228,3 +228,9 @@ def validate_json(json_data):
                 schema_type = schema_name
                 break
     return is_valid, error, schema_type
+
+
+if __name__ == "__main__":
+    A  = {"id": None, "data": [{"file": "single_img.jpg"}], "metadata": "{\"framename\": \"single_img_fashion-v4\", \"original_filename\": \"single_img.jpg\"}", "annotations": [{"concepts": [{"name": "face", "bool": True}], "region": {"bbox": {"xmin": 0.43869650900900903, "ymin": 0.2527734375, "xmax": 0.5399892079579579, "ymax": 0.2527734375}}}, {"concepts": [{"name": "shoes", "bool": True}], "region": {"bbox": {"xmin": 0.39902402402402404, "ymin": 0.898765625, "xmax": 0.5808464714714715, "ymax": 0.9883515625}}}], "splits": ["train"]}
+    print("3B")
+    print(validate_json(A))

--- a/deepomatic/cli/json_schema.py
+++ b/deepomatic/cli/json_schema.py
@@ -228,5 +228,3 @@ def validate_json(json_data):
                 schema_type = schema_name
                 break
     return is_valid, error, schema_type
-
-

--- a/deepomatic/cli/lib/add_images.py
+++ b/deepomatic/cli/lib/add_images.py
@@ -33,8 +33,13 @@ class Client(object):
 def get_all_files_with_ext(path, supported_ext, recursive=True):
     """Scans path to find all supported extensions."""
     all_files = []
-    if os.path.isfile(path) and os.path.splitext(path)[1].lower() in supported_ext:
-        all_files.append(path)
+    if os.path.isfile(path):
+        ext_file = os.path.splitext(path)[1].lower()
+        if ext_file not in supported_ext:
+            LOGGER.warning(
+                "The path {} is neither a supported file {} nor a directory, it has been ignored.".format(path, supported_ext))
+        else:
+            all_files.append(path)
     elif os.path.isdir(path):
         for file in os.listdir(path):
             file_path = os.path.join(path, file)
@@ -42,9 +47,6 @@ def get_all_files_with_ext(path, supported_ext, recursive=True):
                 all_files.extend(get_all_files_with_ext(file_path, supported_ext))
             elif os.path.isfile(file_path) and os.path.splitext(file_path)[1].lower() in supported_ext:
                 all_files.append(file_path)
-    else:
-        raise RuntimeError(
-            "The path {} is neither a supported file {} nor a directory".format(path, supported_ext))
 
     return all_files
 

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -43,4 +43,3 @@ def test_2e2_directory_upload_verbose():
 
 def test_2e2_directory_upload_recursive():
     run_add_images(INPUTS['DIRECTORY'], extra_opts=['--recursive'])
-

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -1,4 +1,4 @@
-#from deepomatic.cli.cli_parser import run
+from deepomatic.cli.cli_parser import run
 from utils import init_files_setup
 
 # ------- Files setup ------------------------------------------------------------------------------------------------ #

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -1,4 +1,4 @@
-from deepomatic.cli.cli_parser import run
+#from deepomatic.cli.cli_parser import run
 from utils import init_files_setup
 
 # ------- Files setup ------------------------------------------------------------------------------------------------ #
@@ -22,6 +22,10 @@ def test_2e2_image_upload():
     run_add_images(INPUTS['IMAGE'])
 
 
+def test_2e2_unsupported_file_upload():
+    run_add_images(INPUTS['UNSUPPORTED_FILE'])
+
+
 def test_2e2_directory_upload():
     run_add_images(INPUTS['DIRECTORY'])
 
@@ -39,3 +43,4 @@ def test_2e2_directory_upload_verbose():
 
 def test_2e2_directory_upload_recursive():
     run_add_images(INPUTS['DIRECTORY'], extra_opts=['--recursive'])
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -155,7 +155,8 @@ def init_files_setup():
     download(tmpdir, base_test_url + 'img.jpg', 'img_dir/img2.jpg')
     download(tmpdir, base_test_url + 'img.jpg', 'img_dir/subdir/img3.jpg')
 
-    unsupported_file = open(tmpdir + '/unsupported_data.abc', 'w')
+    img_pth2 = download(tmpdir, base_test_url + 'img.jpg', 'img_dir2/img2.jpg')
+    unsupported_file = open(tmpdir + '/img_dir2/unsupported_data.abc', 'w')
     unsupported_file.close()
 
     # Download JSON files
@@ -164,6 +165,7 @@ def init_files_setup():
     offline_pred_pth = download(tmpdir, base_test_url + 'offline_predictions.json',
                                 'offline_predictions.json')
     img_dir_pth = os.path.dirname(img_pth)
+    img_dir_pth2 = os.path.dirname(img_pth2)
 
     # Update json for path to match
     patch_json_for_tests(single_img_pth, studio_json_pth, vulcan_json_pth)
@@ -177,7 +179,7 @@ def init_files_setup():
         'STUDIO_JSON': studio_json_pth,
         'OFFLINE_PRED': offline_pred_pth,
         'VULCAN_JSON': vulcan_json_pth,
-        'UNSUPPORTED_FILE': unsupported_file,
+        'UNSUPPORTED_FILE': img_dir_pth2,
     }
     return INPUTS
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -155,7 +155,7 @@ def init_files_setup():
     download(tmpdir, base_test_url + 'img.jpg', 'img_dir/img2.jpg')
     download(tmpdir, base_test_url + 'img.jpg', 'img_dir/subdir/img3.jpg')
 
-    unsupported_file = open(tmpdir+'/unsupported_data.abc', 'w')
+    unsupported_file = open(tmpdir + '/unsupported_data.abc', 'w')
     unsupported_file.close()
     
 
@@ -237,8 +237,3 @@ def modified_environ(*remove, **update):
     finally:
         env.update(update_after)
         [env.pop(k) for k in remove_after]
-
-
-
-
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 import requests
 from contextlib import contextmanager
-#from deepomatic.cli.cli_parser import run
+from deepomatic.cli.cli_parser import run
 
 
 # Define outputs

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -157,7 +157,6 @@ def init_files_setup():
 
     unsupported_file = open(tmpdir + '/unsupported_data.abc', 'w')
     unsupported_file.close()
-    
 
     # Download JSON files
     vulcan_json_pth = download(tmpdir, base_test_url + 'vulcan.json', 'vulcan.json')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 import requests
 from contextlib import contextmanager
-from deepomatic.cli.cli_parser import run
+#from deepomatic.cli.cli_parser import run
 
 
 # Define outputs
@@ -155,6 +155,10 @@ def init_files_setup():
     download(tmpdir, base_test_url + 'img.jpg', 'img_dir/img2.jpg')
     download(tmpdir, base_test_url + 'img.jpg', 'img_dir/subdir/img3.jpg')
 
+    unsupported_file = open(tmpdir+'/unsupported_data.abc', 'w')
+    unsupported_file.close()
+    
+
     # Download JSON files
     vulcan_json_pth = download(tmpdir, base_test_url + 'vulcan.json', 'vulcan.json')
     studio_json_pth = download(tmpdir, base_test_url + 'studio-views.txt', 'studio-views.txt')
@@ -174,6 +178,7 @@ def init_files_setup():
         'STUDIO_JSON': studio_json_pth,
         'OFFLINE_PRED': offline_pred_pth,
         'VULCAN_JSON': vulcan_json_pth,
+        'UNSUPPORTED_FILE': unsupported_file,
     }
     return INPUTS
 
@@ -232,3 +237,8 @@ def modified_environ(*remove, **update):
     finally:
         env.update(update_after)
         [env.pop(k) for k in remove_after]
+
+
+
+
+


### PR DESCRIPTION
Added a little condition so that it ignores not supported files, warns the user about it, but doesn't raise any error.
On mac we have those .DS_Store files in every folder that made it difficult to upload local images using deepocli.