### PR TITLE
Expose font scale and thickness, and set background color depending on score

### DIFF
--- a/deepomatic/cli/cmds/utils.py
+++ b/deepomatic/cli/cmds/utils.py
@@ -62,6 +62,7 @@ class BuildDict(argparse.Action):
     """
     This class is used in argparse. It will transform a chain of name:values into a dict.
     """
+
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
         self._nargs = nargs
         super(BuildDict, self).__init__(option_strings, dest, nargs=nargs, **kwargs)
@@ -149,7 +150,8 @@ def setup_model_cmd_line_parser(mode, cmd, inference_parsers):
         group.add_argument('-ft', '--font_thickness', dest='font_thickness', type=int,
                            help="Text font thickness, must be an int and defaults to 1",
                            default=1)
-        group.add_argument('--unique_background_color', dest='no_background_color', help="If true, draws labels with a unique red background color. By default, the background is red/orange/green depending on the threshold set.", action="store_true")
+        group.add_argument('--unique_background_color', dest='no_background_color',
+                           help="If true, draws labels with a unique red background color. By default, the background is red/orange/green depending on the threshold set.", action="store_true")
         score_group = group.add_mutually_exclusive_group()
         score_group.add_argument('-S', '--draw_scores', dest='draw_scores', help="Overlay the prediction scores. Default behavior.",
                                  action="store_true")

--- a/deepomatic/cli/cmds/utils.py
+++ b/deepomatic/cli/cmds/utils.py
@@ -143,6 +143,12 @@ def setup_model_cmd_line_parser(mode, cmd, inference_parsers):
     if cmd == "draw":
         # Define draw specific options
         group = inference_parsers.add_argument_group('drawing arguments')
+        group.add_argument('-fs', '--font_scale', dest='font_scale', type=float,
+                           help="Text font scale, defaults to 0.5",
+                           default=0.5)
+        group.add_argument('-ft', '--font_thickness', dest='font_thickness', type=int,
+                           help="Text font thickness, must be an int and defaults to 1",
+                           default=1)
         score_group = group.add_mutually_exclusive_group()
         score_group.add_argument('-S', '--draw_scores', dest='draw_scores', help="Overlay the prediction scores. Default behavior.",
                                  action="store_true")

--- a/deepomatic/cli/cmds/utils.py
+++ b/deepomatic/cli/cmds/utils.py
@@ -149,6 +149,7 @@ def setup_model_cmd_line_parser(mode, cmd, inference_parsers):
         group.add_argument('-ft', '--font_thickness', dest='font_thickness', type=int,
                            help="Text font thickness, must be an int and defaults to 1",
                            default=1)
+        group.add_argument('--unique_background_color', dest='background_color', help="If true, draws labels with a unique red background color. By default, the background is red/orange/green depending on the threshold set.", action="store_true")
         score_group = group.add_mutually_exclusive_group()
         score_group.add_argument('-S', '--draw_scores', dest='draw_scores', help="Overlay the prediction scores. Default behavior.",
                                  action="store_true")

--- a/deepomatic/cli/cmds/utils.py
+++ b/deepomatic/cli/cmds/utils.py
@@ -150,8 +150,8 @@ def setup_model_cmd_line_parser(mode, cmd, inference_parsers):
         group.add_argument('-ft', '--font_thickness', dest='font_thickness', type=int,
                            help="Text font thickness, must be an int and defaults to 1",
                            default=1)
-        group.add_argument('--unique_background_color', dest='no_background_color',
-                           help="If true, draws labels with a unique red background color. By default, the background is red/orange/green depending on the threshold set.", action="store_true")
+        group.add_argument('--font_bg_color', default=None, nargs=3,
+                           help="Expect a B G R value. If set, draws labels with a unique background color. By default, the background is red/orange/green depending on the threshold set and the prediction score.", type=int)
         score_group = group.add_mutually_exclusive_group()
         score_group.add_argument('-S', '--draw_scores', dest='draw_scores', help="Overlay the prediction scores. Default behavior.",
                                  action="store_true")

--- a/deepomatic/cli/cmds/utils.py
+++ b/deepomatic/cli/cmds/utils.py
@@ -149,7 +149,7 @@ def setup_model_cmd_line_parser(mode, cmd, inference_parsers):
         group.add_argument('-ft', '--font_thickness', dest='font_thickness', type=int,
                            help="Text font thickness, must be an int and defaults to 1",
                            default=1)
-        group.add_argument('--unique_background_color', dest='background_color', help="If true, draws labels with a unique red background color. By default, the background is red/orange/green depending on the threshold set.", action="store_true")
+        group.add_argument('--unique_background_color', dest='no_background_color', help="If true, draws labels with a unique red background color. By default, the background is red/orange/green depending on the threshold set.", action="store_true")
         score_group = group.add_mutually_exclusive_group()
         score_group.add_argument('-S', '--draw_scores', dest='draw_scores', help="Overlay the prediction scores. Default behavior.",
                                  action="store_true")

--- a/deepomatic/cli/cmds/utils.py
+++ b/deepomatic/cli/cmds/utils.py
@@ -151,7 +151,9 @@ def setup_model_cmd_line_parser(mode, cmd, inference_parsers):
                            help="Text font thickness, must be an int and defaults to 1",
                            default=1)
         group.add_argument('--font_bg_color', default=None, nargs=3,
-                           help="Expect a B G R value. If set, draws labels with a unique background color. By default, the background is red/orange/green depending on the threshold set and the prediction score.", type=int)
+                           help="Expect a B G R value. If set, draws labels with a unique background color."
+                                " By default, the background is red/orange/green depending on the threshold set"
+                                " and the prediction score.", type=int)
         score_group = group.add_mutually_exclusive_group()
         score_group.add_argument('-S', '--draw_scores', dest='draw_scores', help="Overlay the prediction scores. Default behavior.",
                                  action="store_true")

--- a/deepomatic/cli/lib/inference.py
+++ b/deepomatic/cli/lib/inference.py
@@ -81,7 +81,8 @@ class DrawImagePostprocessing(object):
             # Get background color depending on score with a gradient from green to red depending on the threshold set
             else:
                 hsv_color = (60 * (score - self._threshold) / (1 - self._threshold), 255, 200)
-                background_color = tuple(int(i) for i in cv2.cvtColor(np.uint8([[hsv_color]]), cv2.COLOR_HSV2BGR).flatten())
+                background_color = cv2.cvtColor(np.uint8([[hsv_color]]), cv2.COLOR_HSV2BGR).flatten()
+                background_color = background_color.astype('float64')
             # If we have a bounding box
             roi = pred.get('roi')
             if roi is not None:

--- a/deepomatic/cli/lib/inference.py
+++ b/deepomatic/cli/lib/inference.py
@@ -24,9 +24,6 @@ LOGGER = logging.getLogger(__name__)
 SCORE_DECIMAL_PRECISION = 4             # Prediction score decimal number precision
 FONT_SCALE = 0.5                        # Size of the font we draw in the image_output
 BOX_COLOR = (255, 0, 0)                 # Bounding box color (BGR)
-DARK_GREEN_COLOR = (0, 180, 0)          # Text background color (BGR)
-DARK_RED_COLOR = (0, 0, 200)
-ORANGE_COLOR = (0, 110, 250)
 TEXT_COLOR = (255, 255, 255)            # Text color (BGR)
 TAG_TEXT_CORNER = (10, 10)              # Beginning of text tag column (pixel)
 TAG_TEXT_INTERSPACE = 5                 # Vertical space between tags in tag column (pixel)
@@ -53,7 +50,7 @@ class DrawImagePostprocessing(object):
         self._font_scale = kwargs['font_scale']
         self._font_thickness = kwargs['font_thickness']
         self._threshold = kwargs['threshold'] if kwargs['threshold'] is not None else 0
-        self._font_bg_color = tuple(kwargs['font_bg_color'])
+        self._font_bg_color = kwargs['font_bg_color']
 
     def __call__(self, frame):
         frame.output_image = frame.image.copy()
@@ -79,16 +76,11 @@ class DrawImagePostprocessing(object):
             ret, baseline = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, self._font_scale, self._font_thickness)
 
             if self._font_bg_color:
-                background_color = self._font_bg_color
-            # Get background color depending on score
+                background_color = tuple(self._font_bg_color)
+            # Get background color depending on score with a gradient from green to red depending on the threshold set
             else:
-                interval = (1 - self._threshold) / 3
-                if score < interval:
-                    background_color = DARK_RED_COLOR
-                elif score > 1 - interval:
-                    background_color = DARK_GREEN_COLOR
-                else:
-                    background_color = ORANGE_COLOR
+                background_color = (0, 250 * (score - self._threshold) / (1 - self._threshold),
+                                    250 * (1 + self._threshold - score) / (1 - self._threshold))
 
             # If we have a bounding box
             roi = pred.get('roi')

--- a/deepomatic/cli/lib/inference.py
+++ b/deepomatic/cli/lib/inference.py
@@ -80,7 +80,7 @@ class DrawImagePostprocessing(object):
                 background_color = tuple(self._font_bg_color)
             # Get background color depending on score with a gradient from green to red depending on the threshold set
             else:
-                hsv_color = (60 * (score - self._threshold) / (1 - self._threshold),255,200)
+                hsv_color = (60 * (score - self._threshold) / (1 - self._threshold), 255, 200)
                 background_color = tuple(int(i) for i in cv2.cvtColor(np.uint8([[hsv_color]]), cv2.COLOR_HSV2BGR).flatten())
             # If we have a bounding box
             roi = pred.get('roi')

--- a/deepomatic/cli/lib/inference.py
+++ b/deepomatic/cli/lib/inference.py
@@ -120,7 +120,8 @@ class DrawImagePostprocessing(object):
 
                     # Finally draw everything
                     cv2.rectangle(output_image, background_corner1, background_corner2, background_color, -1)
-                    cv2.putText(output_image, label, text_corner, cv2.FONT_HERSHEY_SIMPLEX, self._font_scale, TEXT_COLOR, self._font_thickness)
+                    cv2.putText(output_image, label, text_corner, cv2.FONT_HERSHEY_SIMPLEX,
+                                self._font_scale, TEXT_COLOR, self._font_thickness)
             elif label != '':
                 # First get ideal corners
                 if tag_drawn == 0:

--- a/deepomatic/cli/lib/inference.py
+++ b/deepomatic/cli/lib/inference.py
@@ -54,7 +54,7 @@ class DrawImagePostprocessing(object):
         self._font_scale = kwargs['font_scale']
         self._font_thickness = kwargs['font_thickness']
         self._threshold = kwargs['threshold'] if kwargs['threshold'] is not None else 0
-        self._no_background_color = kwargs['background_color']
+        self._no_background_color = kwargs['no_background_color']
 
     def __call__(self, frame):
         frame.output_image = frame.image.copy()

--- a/deepomatic/cli/lib/inference.py
+++ b/deepomatic/cli/lib/inference.py
@@ -1,6 +1,7 @@
 import sys
 import cv2
 import logging
+import numpy as np
 import threading
 from text_unidecode import unidecode
 from tqdm import tqdm
@@ -79,9 +80,8 @@ class DrawImagePostprocessing(object):
                 background_color = tuple(self._font_bg_color)
             # Get background color depending on score with a gradient from green to red depending on the threshold set
             else:
-                background_color = (0, 250 * (score - self._threshold) / (1 - self._threshold),
-                                    250 * (1 + self._threshold - score) / (1 - self._threshold))
-
+                hsv_color = (60 * (score - self._threshold) / (1 - self._threshold),255,200)
+                background_color = tuple(int(i) for i in cv2.cvtColor(np.uint8([[hsv_color]]), cv2.COLOR_HSV2BGR).flatten())
             # If we have a bounding box
             roi = pred.get('roi')
             if roi is not None:

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -204,6 +204,8 @@ class VideoOutputData(OutputData):
             fourcc = cv2.VideoWriter_fourcc('X', 'V', 'I', 'D')
         elif ext == '.mp4':
             fourcc = cv2.VideoWriter_fourcc('m', 'p', '4', 'v')
+        else:
+            raise Exception("Unsupported video output extension {}".format(ext))
         self._fourcc = fourcc
         self._fps = kwargs['output_fps']
         self._writer = None

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -205,7 +205,7 @@ class VideoOutputData(OutputData):
         elif ext == '.mp4':
             fourcc = cv2.VideoWriter_fourcc('m', 'p', '4', 'v')
         else:
-            raise DeepoUnknownOutputError('Unsupported video output extension')
+            raise DeepoUnknownOutputError(f'Unsupported video output extension: {ext}')
         self._fourcc = fourcc
         self._fps = kwargs['output_fps']
         self._writer = None

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -199,11 +199,13 @@ class VideoOutputData(OutputData):
 
     def __init__(self, descriptor, **kwargs):
         super(VideoOutputData, self).__init__(descriptor, **kwargs)
-        ext = os.path.splitext(descriptor)[1]
+        ext = os.path.splitext(descriptor)[1].lower()
         if ext == '.avi':
             fourcc = cv2.VideoWriter_fourcc('X', 'V', 'I', 'D')
         elif ext == '.mp4':
             fourcc = cv2.VideoWriter_fourcc('m', 'p', '4', 'v')
+        else:
+            raise DeepoUnknownOutputError('Unsupported video output extension')
         self._fourcc = fourcc
         self._fps = kwargs['output_fps']
         self._writer = None

--- a/deepomatic/cli/output_data.py
+++ b/deepomatic/cli/output_data.py
@@ -204,8 +204,6 @@ class VideoOutputData(OutputData):
             fourcc = cv2.VideoWriter_fourcc('X', 'V', 'I', 'D')
         elif ext == '.mp4':
             fourcc = cv2.VideoWriter_fourcc('m', 'p', '4', 'v')
-        else:
-            raise DeepoUnknownOutputError(f'Unsupported video output extension: {ext}')
         self._fourcc = fourcc
         self._fps = kwargs['output_fps']
         self._writer = None

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -135,6 +135,12 @@ def test_e2e_image_draw_image_scores_and_labels():
 def test_e2e_image_draw_image_no_scores_and_no_labels():
     run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--no_draw_scores', '--no_draw_labels'])
 
+def test_e2e_image_draw_image_font_scale_and_thickness():
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['-fs', '2'])
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['-ft', '2'])
+
+def test_e2e_image_draw_image_font_bg_color():
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--font_bg_color', '255 0 0'])
 
 def test_e2e_image_draw_from_file():
     run_draw(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1, extra_opts=['--from_file', INPUTS['OFFLINE_PRED']])

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -135,12 +135,15 @@ def test_e2e_image_draw_image_scores_and_labels():
 def test_e2e_image_draw_image_no_scores_and_no_labels():
     run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--no_draw_scores', '--no_draw_labels'])
 
+
 def test_e2e_image_draw_image_font_scale_and_thickness():
     run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['-fs', '2'])
     run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['-ft', '2'])
 
+
 def test_e2e_image_draw_image_font_bg_color():
     run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--font_bg_color', '255 0 0'])
+
 
 def test_e2e_image_draw_from_file():
     run_draw(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1, extra_opts=['--from_file', INPUTS['OFFLINE_PRED']])

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -142,7 +142,7 @@ def test_e2e_image_draw_image_font_scale_and_thickness():
 
 
 def test_e2e_image_draw_image_font_bg_color():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--font_bg_color', '255 0 0'])
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--font_bg_color', '255', '0', '0'])
 
 
 def test_e2e_image_draw_from_file():

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -279,7 +279,7 @@ class TestSite(object):
         args = "site intervention status -i {} --api_url {}".format(intervention_id, customer_api_url)
         result = call_deepo(args, api_key=customer_api_key)
         assert set(result.keys()) == set(['id', 'name', 'config_id', 'questions', 'answers', 'site_id',
-                                          'app_version_id', 'start_date', 'end_date', 'workflow_parameters', 'update_date',
+                                          'app_version_id', 'create_date', 'workflow_parameters', 'update_date',
                                           'review_date', 'tags', 'assigned_user_id', 'enabled', 'metadata'])
         args = "site intervention delete -i {} --api_url {}".format(intervention_id, customer_api_url)
         result = call_deepo(args, api_key=customer_api_key)


### PR DESCRIPTION
1. Fix error if the output extension is in capital letter, and raise an error if the extension is not supported (otherwise we have the error "local variable fourcc referenced before assignment"
2. Expose font scale and font thickness to the user for `deepo draw`
3. Set the background color according to the score : if the threshold is none, it's green/orange/red if the score is >0.66, in between, or < 0.33 (otherwise the interval [threshold-1] is divided in 3)
4. Add parameter "unique_background_color" in case we want to disable the point 3 and have all the background in red as before

Closes #190 #110 #109 