### PR TITLE
Make tests fail on error logs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 license_file = LICENSE
 
 [tool:pytest]
-addopts = -vv
+addopts = -vv -o log_cli=true
 testpaths =
     tests
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from gevent.monkey import patch_all
 patch_all(thread=False, time=False, subprocess=False)
-import pytest
+import pytest  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,13 @@
 from gevent.monkey import patch_all
 patch_all(thread=False, time=False, subprocess=False)
+import pytest
+
+
+@pytest.fixture
+def no_error_logs(caplog):
+    yield
+
+    records = caplog.get_records('call')
+    # Check we got no log in error
+    for log in records:
+        assert log.levelname not in {'ERROR', 'CRITICAL'}

--- a/tests/test_blur.py
+++ b/tests/test_blur.py
@@ -35,7 +35,7 @@ def run_blur(*args, **kwargs):
         })
     ]
 )
-def test_e2e_image_blur(outputs, expected):
+def test_e2e_image_blur(outputs, expected, no_error_logs):
     run_blur(INPUTS['IMAGE'], outputs, **expected)
 
 
@@ -61,7 +61,7 @@ def test_e2e_image_blur(outputs, expected):
         })
     ]
 )
-def test_e2e_video_blur(outputs, expected):
+def test_e2e_video_blur(outputs, expected, no_error_logs):
     run_blur(INPUTS['VIDEO'], outputs, **expected)
 
 
@@ -87,45 +87,54 @@ def test_e2e_video_blur(outputs, expected):
         })
     ]
 )
-def test_e2e_directory_blur(outputs, expected):
+def test_e2e_directory_blur(outputs, expected, no_error_logs):
     run_blur(INPUTS['DIRECTORY'], outputs, **expected)
 
 
 # # ------- Special Options Tests -------------------------------------------------------------------------------------- #
 
 
-def test_e2e_image_blur_image_verbose():
-    run_blur(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--verbose'])
+def test_e2e_image_blur_image_verbose(no_error_logs):
+    run_blur(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--verbose'])
 
 
-def test_e2e_image_blur_image_threshold():
-    run_blur(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['-t', '0.5'])
+def test_e2e_image_blur_image_threshold(no_error_logs):
+    run_blur(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['-t', '0.5'])
 
 
-def test_e2e_video_blur_video_fps():
-    run_blur(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1, extra_opts=['--output_fps', '2'])
-    run_blur(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1, extra_opts=['--input_fps', '2'])
+def test_e2e_video_blur_video_fps(no_error_logs):
+    run_blur(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1,
+             extra_opts=['--output_fps', '2'])
+    run_blur(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1,
+             extra_opts=['--input_fps', '2'])
 
 
 @pytest.mark.skip(reason="window not handled by test")
-def test_e2e_image_blur_image_window():
-    run_blur(INPUTS['IMAGE'], [OUTPUTS['WINDOW']], expect_nb_image=1, extra_opts=['--fullscreen'])
+def test_e2e_image_blur_image_window(no_error_logs):
+    run_blur(INPUTS['IMAGE'], [OUTPUTS['WINDOW']], expect_nb_image=1,
+             extra_opts=['--fullscreen'])
 
 
-def test_e2e_image_blur_image_method():
-    run_blur(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--blur_method', 'pixel'])
+def test_e2e_image_blur_image_method(no_error_logs):
+    run_blur(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--blur_method', 'pixel'])
 
 
-def test_e2e_image_blur_image_strengh():
-    run_blur(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--blur_strength', '5'])
+def test_e2e_image_blur_image_strengh(no_error_logs):
+    run_blur(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--blur_strength', '5'])
 
 
-def test_e2e_image_blur_image_method_and_strenght():
-    run_blur(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--blur_method', 'pixel', '--blur_strength', '5'])
+def test_e2e_image_blur_image_method_and_strength(no_error_logs):
+    run_blur(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--blur_method', 'pixel', '--blur_strength', '5'])
 
 
-def test_e2e_image_blur_from_file():
-    run_blur(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1, extra_opts=['--from_file', INPUTS['OFFLINE_PRED']])
+def test_e2e_image_blur_from_file(no_error_logs):
+    run_blur(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1,
+             extra_opts=['--from_file', INPUTS['OFFLINE_PRED']])
 
 
 def test_e2e_image_corrupted_blur_image():

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -35,7 +35,7 @@ def run_draw(*args, **kwargs):
         })
     ]
 )
-def test_e2e_image_draw(outputs, expected):
+def test_e2e_image_draw(outputs, expected, no_error_logs):
     run_draw(INPUTS['IMAGE'], outputs, **expected)
 
 
@@ -61,7 +61,7 @@ def test_e2e_image_draw(outputs, expected):
         })
     ]
 )
-def test_e2e_video_draw(outputs, expected):
+def test_e2e_video_draw(outputs, expected, no_error_logs):
     run_draw(INPUTS['VIDEO'], outputs, **expected)
 
 
@@ -87,66 +87,79 @@ def test_e2e_video_draw(outputs, expected):
         })
     ]
 )
-def test_e2e_directory_draw(outputs, expected):
+def test_e2e_directory_draw(outputs, expected, no_error_logs):
     run_draw(INPUTS['DIRECTORY'], outputs, **expected)
 
 
 # ------- Special Options Tests -------------------------------------------------------------------------------------- #
 
 
-def test_e2e_image_draw_image_verbose():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--verbose'])
+def test_e2e_image_draw_image_verbose(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--verbose'])
 
 
-def test_e2e_image_draw_image_threshold():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['-t', '0.5'])
+def test_e2e_image_draw_image_threshold(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['-t', '0.5'])
 
 
-def test_e2e_video_draw_video_fps():
+def test_e2e_video_draw_video_fps(no_error_logs):
     run_draw(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1, extra_opts=['--output_fps', '2'])
     run_draw(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1, extra_opts=['--input_fps', '2'])
 
 
 @pytest.mark.skip(reason="window not handled by test")
-def test_e2e_image_draw_image_window():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['WINDOW']], expect_nb_image=1, extra_opts=['--fullscreen'])
+def test_e2e_image_draw_image_window(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['WINDOW']], expect_nb_image=1,
+             extra_opts=['--fullscreen'])
 
 
-def test_e2e_image_draw_image_scores():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--draw_scores'])
+def test_e2e_image_draw_image_scores(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--draw_scores'])
 
 
-def test_e2e_image_draw_image_no_scores():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--no_draw_scores'])
+def test_e2e_image_draw_image_no_scores(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--no_draw_scores'])
 
 
-def test_e2e_image_draw_image_labels():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--draw_labels'])
+def test_e2e_image_draw_image_labels(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--draw_labels'])
 
 
-def test_e2e_image_draw_image_no_labels():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--no_draw_labels'])
+def test_e2e_image_draw_image_no_labels(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--no_draw_labels'])
 
 
-def test_e2e_image_draw_image_scores_and_labels():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--draw_scores', '--draw_labels'])
+def test_e2e_image_draw_image_scores_and_labels(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--draw_scores', '--draw_labels'])
 
 
-def test_e2e_image_draw_image_no_scores_and_no_labels():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--no_draw_scores', '--no_draw_labels'])
+def test_e2e_image_draw_image_no_scores_and_no_labels(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--no_draw_scores', '--no_draw_labels'])
 
 
-def test_e2e_image_draw_image_font_scale_and_thickness():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['-fs', '2'])
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['-ft', '2'])
+def test_e2e_image_draw_image_font_scale_and_thickness(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['-fs', '2'])
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['-ft', '2'])
 
 
-def test_e2e_image_draw_image_font_bg_color():
-    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1, extra_opts=['--font_bg_color', '255', '0', '0'])
+def test_e2e_image_draw_image_font_bg_color(no_error_logs):
+    run_draw(INPUTS['IMAGE'], [OUTPUTS['IMAGE']], expect_nb_image=1,
+             extra_opts=['--font_bg_color', '255', '0', '0'])
 
 
-def test_e2e_image_draw_from_file():
-    run_draw(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1, extra_opts=['--from_file', INPUTS['OFFLINE_PRED']])
+def test_e2e_image_draw_from_file(no_error_logs):
+    run_draw(INPUTS['VIDEO'], [OUTPUTS['VIDEO']], expect_nb_video=1,
+             extra_opts=['--from_file', INPUTS['OFFLINE_PRED']])
 
 
 def test_e2e_image_corrupted_draw_image():

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -35,7 +35,7 @@ def run_infer(*args, **kwargs):
         })
     ]
 )
-def test_e2e_image_infer(outputs, expected):
+def test_e2e_image_infer(outputs, expected, no_error_logs):
     run_infer(INPUTS['IMAGE'], outputs, **expected)
 
 
@@ -61,7 +61,7 @@ def test_e2e_image_infer(outputs, expected):
         })
     ]
 )
-def test_e2e_video_infer(outputs, expected):
+def test_e2e_video_infer(outputs, expected, no_error_logs):
     run_infer(INPUTS['VIDEO'], outputs, **expected)
 
 
@@ -87,24 +87,28 @@ def test_e2e_video_infer(outputs, expected):
         })
     ]
 )
-def test_e2e_directory_infer(outputs, expected):
+def test_e2e_directory_infer(outputs, expected, no_error_logs):
     run_infer(INPUTS['DIRECTORY'], outputs, **expected)
 
 
 # # ------- Special Options Tests -------------------------------------------------------------------------------------- #
 
 
-def test_e2e_image_infer_json_verbose():
-    run_infer(INPUTS['IMAGE'], [OUTPUTS['NO_WILDCARD_JSON']], expect_nb_json=1, extra_opts=['--verbose'])
+def test_e2e_image_infer_json_verbose(no_error_logs):
+    run_infer(INPUTS['IMAGE'], [OUTPUTS['NO_WILDCARD_JSON']], expect_nb_json=1,
+              extra_opts=['--verbose'])
 
 
-def test_e2e_image_infer_json_threshold():
-    run_infer(INPUTS['IMAGE'], [OUTPUTS['NO_WILDCARD_JSON']], expect_nb_json=1, extra_opts=['-t', '0.5'])
+def test_e2e_image_infer_json_threshold(no_error_logs):
+    run_infer(INPUTS['IMAGE'], [OUTPUTS['NO_WILDCARD_JSON']], expect_nb_json=1,
+              extra_opts=['-t', '0.5'])
 
 
 def test_e2e_image_corrupted_infer_json():
-    run_infer(INPUTS['IMAGE_CORRUPTED'], [OUTPUTS['INT_WILDCARD_JSON']], expect_nb_json=0)
+    run_infer(INPUTS['IMAGE_CORRUPTED'], [OUTPUTS['INT_WILDCARD_JSON']],
+              expect_nb_json=0)
 
 
-def test_e2e_image_infer_reproduce_input_dir_struct():
-    run_infer(INPUTS['DIRECTORY'], [OUTPUTS['STR_WILDCARD_JSON']], expect_nb_json=2, expect_nb_subdir=1, extra_opts=['--recursive'])
+def test_e2e_image_infer_reproduce_input_dir_struct(no_error_logs):
+    run_infer(INPUTS['DIRECTORY'], [OUTPUTS['STR_WILDCARD_JSON']], expect_nb_json=2,
+              expect_nb_subdir=1, extra_opts=['--recursive'])

--- a/tests/test_noop.py
+++ b/tests/test_noop.py
@@ -25,7 +25,7 @@ def run_noop(*args, **kwargs):
         ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 1}}}),
     ]
 )
-def test_e2e_image_infer(outputs, expected):
+def test_e2e_image_infer(outputs, expected, no_error_logs):
     run_noop(INPUTS['IMAGE'], outputs, **expected)
 
 
@@ -41,7 +41,7 @@ def test_e2e_image_infer(outputs, expected):
         ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 21}}}),
     ]
 )
-def test_e2e_video_infer(outputs, expected):
+def test_e2e_video_infer(outputs, expected, no_error_logs):
     run_noop(INPUTS['VIDEO'], outputs, **expected)
 
 
@@ -57,5 +57,5 @@ def test_e2e_video_infer(outputs, expected):
         ([OUTPUTS['DIR']], {'expect_nb_subdir': 1, 'expect_subir': {OUTPUTS['DIR']: {'expect_nb_image': 2, 'expect_nb_subdir': 1}}}),
     ]
 )
-def test_e2e_directory_infer(outputs, expected):
+def test_e2e_directory_infer(outputs, expected, no_error_logs):
     run_noop(INPUTS['DIRECTORY'], outputs, **expected)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -51,7 +51,7 @@ def app_version():
 
 
 class TestPlatform(object):
-    def test_app(self):
+    def test_app(self, no_error_logs):
         args = "platform app create -n test -d abc -w {} -c {}".format(WORKFLOW_PATH, CUSTOM_NODES_PATH)
         result = call_deepo(args)
         message, app_id = result.split(':')
@@ -65,7 +65,7 @@ class TestPlatform(object):
         message = call_deepo(args)
         assert message == 'App{} deleted'.format(app_id)
 
-    def test_app_without_workflow(self):
+    def test_app_without_workflow(self, no_error_logs):
 
         args = "platform app create -n test -d abc"
         with pytest.raises(ValueError):
@@ -90,7 +90,7 @@ class TestPlatform(object):
             # workflow yaml and specs are exclusive
             result = call_deepo(args)
 
-    def test_appversion(self):
+    def test_appversion(self, no_error_logs):
         with app() as app_id:
             args = "platform app-version create -n test_av -d abc -a {} -r 44363 44364".format(app_id)
             result = call_deepo(args)
@@ -105,7 +105,7 @@ class TestPlatform(object):
             message = call_deepo(args)
             assert message == 'App version{} deleted'.format(app_version_id)
 
-    def test_service(self):
+    def test_service(self, no_error_logs):
         for service in ['customer-api', 'camera-server']:
             with app() as app_id:
                 args = "platform service create -a {} -n {}".format(app_id, service)

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -158,7 +158,7 @@ def site():
 
 
 class TestSite(object):
-    def test_all(self):
+    def test_all(self, no_error_logs):
         with setup() as manager:
             # create site
             app_version_id = str(uuid4())
@@ -230,7 +230,7 @@ class TestSite(object):
             manager.uninstall(site_id)
             assert(site_id not in manager.list())
 
-    def test_site(self):
+    def test_site(self, no_error_logs):
         with app_version() as (app_version_id, app_id):
             args = "site create -n test_si -d xyz -v {}".format(app_version_id)
             result = call_deepo(args)
@@ -245,7 +245,7 @@ class TestSite(object):
             message = call_deepo(args)
             assert message == 'Site{} deleted'.format(site_id)
 
-    def test_site_deployment_manifest(self):
+    def test_site_deployment_manifest(self, no_error_logs):
         for service in ['customer-api', 'camera-server']:
             with site() as (site_id, app_version_id, app_id):
                 # add extra service
@@ -270,7 +270,7 @@ class TestSite(object):
                 if service == 'customer-api':
                     assert 'kind: Ingress' in message
 
-    def test_intervention(self):
+    def test_intervention(self, no_error_logs):
         args = "site intervention create -n ciao --api_url {} -m hello:2".format(customer_api_url)
         result = call_deepo(args, api_key=customer_api_key)
         intervention_id = result

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -18,28 +18,28 @@ def run_add_images(test_input, extra_opts=None):
 # ------- Studio Upload Tests----------------------------------------------------------------------------------------- #
 
 
-def test_2e2_image_upload():
+def test_2e2_image_upload(no_error_logs):
     run_add_images(INPUTS['IMAGE'])
 
 
-def test_2e2_unsupported_file_upload():
+def test_2e2_unsupported_file_upload(no_error_logs):
     run_add_images(INPUTS['UNSUPPORTED_FILE'])
 
 
-def test_2e2_directory_upload():
+def test_2e2_directory_upload(no_error_logs):
     run_add_images(INPUTS['DIRECTORY'])
 
 
-def test_2e2_studio_json_upload():
+def test_2e2_studio_json_upload(no_error_logs):
     run_add_images(INPUTS['STUDIO_JSON'], extra_opts=['--txt'])
 
 
 # ------- Special Options Tests -------------------------------------------------------------------------------------- #
 
 
-def test_2e2_directory_upload_verbose():
+def test_2e2_directory_upload_verbose(no_error_logs):
     run_add_images(INPUTS['DIRECTORY'], extra_opts=['--verbose'])
 
 
-def test_2e2_directory_upload_recursive():
+def test_2e2_directory_upload_recursive(no_error_logs):
     run_add_images(INPUTS['DIRECTORY'], extra_opts=['--recursive'])


### PR DESCRIPTION
Created a pytest fixture that checks at the end of the test that no ERROR|CRITICAL logs have been thrown