### PR TITLE
Check if box is valid before blur to avoid float division by zero

### DIFF
--- a/deepomatic/cli/lib/inference.py
+++ b/deepomatic/cli/lib/inference.py
@@ -145,22 +145,22 @@ class BlurImagePostprocessing(object):
             if roi is not None:
                 # Retrieve coordinates
                 xmin, ymin, xmax, ymax = get_coordinates_from_roi(roi, width, height)
-
-                # Draw
-                if self._method == 'black':
-                    cv2.rectangle(output_image, (xmin, ymin), (xmax, ymax), (0, 0, 0), -1)
-                elif self._method == 'gaussian':
-                    rectangle = output_image[ymin:ymax, xmin:xmax]
-                    rectangle = cv2.GaussianBlur(rectangle, (0, 0), self._strength)
-                    output_image[ymin:ymax, xmin:xmax] = rectangle
-                elif self._method == 'pixel':
-                    rectangle = output_image[ymin:ymax, xmin:xmax]
-                    small = cv2.resize(rectangle, (0, 0),
-                                       fx=1. / min((xmax - xmin), self._strength),
-                                       fy=1. / min((ymax - ymin), self._strength))
-                    rectangle = cv2.resize(small, ((xmax - xmin), (ymax - ymin)),
-                                           interpolation=cv2.INTER_NEAREST)
-                    output_image[ymin:ymax, xmin:xmax] = rectangle
+                if (xmax - xmin > 0) and (ymax - ymin > 0):
+                    # Draw
+                    if self._method == 'black':
+                        cv2.rectangle(output_image, (xmin, ymin), (xmax, ymax), (0, 0, 0), -1)
+                    elif self._method == 'gaussian':
+                        rectangle = output_image[ymin:ymax, xmin:xmax]
+                        rectangle = cv2.GaussianBlur(rectangle, (0, 0), self._strength)
+                        output_image[ymin:ymax, xmin:xmax] = rectangle
+                    elif self._method == 'pixel':
+                        rectangle = output_image[ymin:ymax, xmin:xmax]
+                        small = cv2.resize(rectangle, (0, 0),
+                                        fx=1. / min((xmax - xmin), self._strength),
+                                        fy=1. / min((ymax - ymin), self._strength))
+                        rectangle = cv2.resize(small, ((xmax - xmin), (ymax - ymin)),
+                                            interpolation=cv2.INTER_NEAREST)
+                        output_image[ymin:ymax, xmin:xmax] = rectangle
 
 
 class PrepareInferenceThread(Thread):


### PR DESCRIPTION
When the model threshold is too low (set to 0), it provides bad predictions that make the blur command crash:
```
[ERROR 2022-01-25 10:51:50,309] Encountered an unexpected exception during routine: Traceback (most recent call last):
  File "/deepocli/deepomatic/cli/thread_base.py", line 216, in run
    self._run()
  File "/deepocli/deepomatic/cli/thread_base.py", line 204, in _run
    msg_out = self.process_msg(msg_in)
  File "/deepocli/deepomatic/cli/output_data.py", line 150, in process_msg
    self.postprocessing(frame)
  File "/deepocli/deepomatic/cli/lib/inference.py", line 162, in __call__
    fy=1. / min((ymax - ymin), self._strength))
ZeroDivisionError: float division by zero
```

So I added a check in the blur command to check the box is valid (xmin != xmax and ymin != ymax) before blurring